### PR TITLE
Shinymeta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ vignettes/*.pdf
 
 shapes/
 .Rproj.user
+
+# Ignore .Rprofile, which contains sensitive environment variables
+.Rprofile

--- a/flexdashboard/access-to-care.Rmd
+++ b/flexdashboard/access-to-care.Rmd
@@ -26,6 +26,7 @@ library(leaflet)
 library(DT)
 library(metricsgraphics)
 library(pins)
+library(shinymeta)
 
 if(Sys.getenv("R_CONFIG_ACTIVE") == "rsconnect") {
   boardname <- "rsconnect"
@@ -47,22 +48,25 @@ over <- "#0072B2"
 at_level <- "#008b00"
 hospital_color <- "#F0E442"
 
-state_info <- reactive({
+state_info <- metaReactive({
   states %>% 
-    filter(full == input$state) 
+    filter(full == ..(input$state)) 
 })
 
-county_map <-  reactive({
-  curr_state <- state_info() %>%
+curr_state <- metaReactive({
+  ..(state_info()) %>% 
     pull(state_id)
+})
+
+county_map <-  metaReactive({
   pin_get("atc-county-map", board = boardname) %>% 
-    filter(state_id == !! curr_state) %>%
+    filter(state_id == !! ..(curr_state())) %>%
     collect()
 })
 
-base_map <- reactive({
+base_map <- metaReactive({
   pin_get("atc-base-map", boardname) %>%
-    filter(full %in% !! input$state) %>%
+    filter(full %in% ..(input$state)) %>%
     collect()
 })
 ```
@@ -130,16 +134,16 @@ renderValueBox({
 ```
 
 
-Row {.tabset}
+Row {.tabset data-height=950}
 -----------------------------------------------------------------------
 
 ### County Map
 
 Breakdown of counties and their status based on county population compared to the number of hospitals
 
-
 ```{r}
-initial_map <- leaflet() %>%
+output$map <- metaRender(renderLeaflet, {
+  initial_map <- leaflet() %>%
   addProviderTiles(providers$CartoDB) %>%
   addLegend(
     "bottomright", 
@@ -151,22 +155,18 @@ initial_map <- leaflet() %>%
     title  = "Legend",
     opacity = 0.5
     )
-
-renderLeaflet({
-  curr_state <- state_info() %>%
-    pull(state_id)
   
   locations <- pin_get("atc-hospitals", board = boardname) %>%
-    filter(state_id == !! curr_state) %>%
+    filter(state_id == !! ..(curr_state())) %>%
     select(longitude, latitude) %>%
     collect() %>%
     mutate_all(round, 1) %>%
     count(longitude, latitude) %>%
     mutate(popup = paste0("Hospitals: ", n))
   
-  base_map() %>%
+  ..(base_map()) %>%
     select(popup, color, county_id) %>%
-    inner_join(county_map(), by = "county_id") %>%
+    inner_join(..(county_map()), by = "county_id") %>%
     group_by(county_id, shape_id) %>%
     group_map(~.x) %>%
     reduce(
@@ -188,20 +188,70 @@ renderLeaflet({
         fillColor = hospital_color, color = "gray", 
         fillOpacity = 0.7,weight = 1)
 })
+
+leafletOutput("map")
 ```
 
 ### County summary
 
 
 ```{r}
-renderDataTable({
+output$table <- metaRender(renderDataTable, {
   pin_get("atc-county-table", board = boardname)  %>%
-    filter(full == !! input$state) %>%
+    filter(full == ..(input$state)) %>%
     select(-full) %>%
     collect() %>%
     datatable(class = 'cell-border stripe')
 })
+
+DTOutput("table")
 ```
+
+Row {data-height=50}
+-----------------------------------------------------------------------
+```{r}
+actionButton("code", "R code", icon("code"))
+observeEvent(input$code, {
+  code <- expandChain(
+    "# Environment setup ----",
+    quote({
+      library(dplyr)
+      library(purrr)
+      library(leaflet)
+      library(DT)
+      library(pins)
+      
+      if(Sys.getenv("R_CONFIG_ACTIVE") == "rsconnect") {
+        boardname <- "rsconnect"
+        board_register_rsconnect(
+          server = Sys.getenv("connect_url"),
+          key = Sys.getenv("connect_key")
+        )
+      } else {
+        boardname <- "local"
+        board_register(boardname)  
+      }
+      
+      states <- pin_get("atc-states", board = boardname) %>% collect()
+      under <- "#CC79A7"
+      over <- "#0072B2"
+      at_level <- "#008b00"
+      hospital_color <- "#F0E442"
+    }),
+    "# Leaflet plot ----",
+    output$map(),
+    "# County details DataTable ----",
+    output$table()
+  )
+  displayCodeModal(
+    code,
+    title = "Access to Care Code",
+    size = "l",
+    fontSize = 16
+  )
+})
+```
+
 
 Model {.storyboard}
 ======================================================================

--- a/flexdashboard/access-to-care.Rmd
+++ b/flexdashboard/access-to-care.Rmd
@@ -28,6 +28,7 @@ library(metricsgraphics)
 library(pins)
 library(shinymeta)
 library(shinyAce)
+library(clipr)
 
 if(Sys.getenv("R_CONFIG_ACTIVE") == "rsconnect") {
   boardname <- "rsconnect"

--- a/flexdashboard/access-to-care.Rmd
+++ b/flexdashboard/access-to-care.Rmd
@@ -27,6 +27,7 @@ library(DT)
 library(metricsgraphics)
 library(pins)
 library(shinymeta)
+library(shinyAce)
 
 if(Sys.getenv("R_CONFIG_ACTIVE") == "rsconnect") {
   boardname <- "rsconnect"

--- a/flexdashboard/manifest.json
+++ b/flexdashboard/manifest.json
@@ -405,6 +405,40 @@
         "Built": "R 3.6.1; ; 2019-09-26 13:43:51 UTC; unix"
       }
     },
+    "clipr": {
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Type": "Package",
+        "Package": "clipr",
+        "Title": "Read and Write from the System Clipboard",
+        "Version": "0.6.0",
+        "Authors@R": "\n    c(person(given = \"Matthew\",\n             family = \"Lincoln\",\n             role = c(\"aut\", \"cre\"),\n             email = \"matthew.d.lincoln@gmail.com\",\n             comment = c(ORCID = \"0000-0002-4387-3384\")),\n      person(given = \"Louis\",\n             family = \"Maddox\",\n             role = \"ctb\"),\n      person(given = \"Steve\",\n             family = \"Simpson\",\n             role = \"ctb\"),\n      person(given = \"Jennifer\",\n             family = \"Bryan\",\n             role = \"ctb\"))",
+        "Description": "Simple utility functions to read from and write to\n    the Windows, OS X, and X11 clipboards.",
+        "License": "GPL-3",
+        "URL": "https://github.com/mdlincoln/clipr",
+        "BugReports": "https://github.com/mdlincoln/clipr/issues",
+        "Imports": "utils",
+        "Suggests": "covr, knitr, rmarkdown, rstudioapi (>= 0.5), testthat (>=\n2.0.0)",
+        "VignetteBuilder": "knitr",
+        "Encoding": "UTF-8",
+        "Language": "en-US",
+        "LazyData": "TRUE",
+        "RoxygenNote": "6.1.1",
+        "SystemRequirements": "xclip (https://github.com/astrand/xclip) or xsel\n(http://www.vergenet.net/~conrad/software/xsel/) for accessing\nthe X11 clipboard",
+        "NeedsCompilation": "no",
+        "Packaged": "2019-04-14 19:41:05 UTC; mlincoln",
+        "Author": "Matthew Lincoln [aut, cre] (<https://orcid.org/0000-0002-4387-3384>),\n  Louis Maddox [ctb],\n  Steve Simpson [ctb],\n  Jennifer Bryan [ctb]",
+        "Maintainer": "Matthew Lincoln <matthew.d.lincoln@gmail.com>",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-04-15 15:22:49 UTC",
+        "Built": "R 3.6.1; ; 2019-08-05 10:30:31 UTC; unix"
+      }
+    },
     "colorspace": {
       "Source": "latest",
       "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
@@ -2846,7 +2880,7 @@
   },
   "files": {
     "access-to-care.Rmd": {
-      "checksum": "cd8ed9932aa2dcc78f17a209f87567cf"
+      "checksum": "a1cf2452a0bc9a938751dc40af4bfdfb"
     },
     "metadata.yml": {
       "checksum": "6a089bf7d5d485378e5a4f92cad4ad42"
@@ -2874,6 +2908,9 @@
     },
     "packrat/desc/cli": {
       "checksum": "a65c30681395287318eddb8c16cc4eec"
+    },
+    "packrat/desc/clipr": {
+      "checksum": "f2766360d0275acd9e99ede1131ebc1d"
     },
     "packrat/desc/colorspace": {
       "checksum": "ca7b0eb3d7b8bafd2b6631c90ac81cea"
@@ -3125,7 +3162,7 @@
       "checksum": "e3293f6b22b641db2a78a50f8c24d8eb"
     },
     "packrat/packrat.lock": {
-      "checksum": "a74cc28cc84108032b7026430c9d9fab"
+      "checksum": "6805d5600a9111fa86adae46f00df07b"
     },
     "RStudio1.png": {
       "checksum": "288da77036023512c0adbf27de9fe9c2"

--- a/flexdashboard/manifest.json
+++ b/flexdashboard/manifest.json
@@ -2179,6 +2179,37 @@
         "Built": "R 3.6.2; ; 2019-12-27 20:42:36 UTC; unix"
       }
     },
+    "shinyAce": {
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "shinyAce",
+        "Type": "Package",
+        "Title": "Ace Editor Bindings for Shiny",
+        "Version": "0.4.0",
+        "Date": "2019-7-9",
+        "Authors@R": "c(\n  person(\"Vincent\", \"Nijs\", role = c(\"aut\", \"cre\"), email = \"radiant@rady.ucsd.edu\"),\n  person(\"Forest\", \"Fang\", role = \"aut\", email = \"forest.fang@outlook.com\"),\n  person(family = \"Trestle Technology, LLC\", role = \"aut\", email = \"cran@trestletechnology.net\"),\n  person(\"Jeff\", \"Allen\", role = \"aut\", email = \"cran@trestletechnology.net\"),\n  person(family = \"Institut de Radioprotection et de Surete Nucleaire\", role = c(\"cph\"), email = \"yann.richet@irsn.fr\"),\n  person(family = \"Ajax.org B.V.\", role = c(\"ctb\", \"cph\"), comment = \"Ace\"))",
+        "Description": "Ace editor bindings to enable a rich text editing environment\n    within Shiny.",
+        "License": "MIT + file LICENSE",
+        "Depends": "R (>= 3.3.0)",
+        "Imports": "shiny (>= 1.0.5), jsonlite",
+        "Suggests": "testthat (>= 2.0.0), dplyr (>= 0.8.3)",
+        "BugReports": "https://github.com/trestletech/shinyAce/issues",
+        "Encoding": "UTF-8",
+        "RoxygenNote": "6.1.1",
+        "NeedsCompilation": "no",
+        "Packaged": "2019-07-09 16:14:01 UTC; vnijs",
+        "Author": "Vincent Nijs [aut, cre],\n  Forest Fang [aut],\n  Trestle Technology, LLC [aut],\n  Jeff Allen [aut],\n  Institut de Radioprotection et de Surete Nucleaire [cph],\n  Ajax.org B.V. [ctb, cph] (Ace)",
+        "Maintainer": "Vincent Nijs <radiant@rady.ucsd.edu>",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-07-09 16:50:04 UTC",
+        "Built": "R 3.6.1; ; 2019-09-21 13:23:29 UTC; unix"
+      }
+    },
     "shinymeta": {
       "Source": "github",
       "Repository": null,
@@ -2815,7 +2846,7 @@
   },
   "files": {
     "access-to-care.Rmd": {
-      "checksum": "0001b62e1832dd58f0f9dcac549c0d72"
+      "checksum": "cd8ed9932aa2dcc78f17a209f87567cf"
     },
     "metadata.yml": {
       "checksum": "6a089bf7d5d485378e5a4f92cad4ad42"
@@ -3030,6 +3061,9 @@
     "packrat/desc/shiny": {
       "checksum": "71028b0db6da338537425e45f4e96ce3"
     },
+    "packrat/desc/shinyAce": {
+      "checksum": "c5b368a626347b0fecc6cc57ab54be7d"
+    },
     "packrat/desc/shinymeta": {
       "checksum": "23e8bfe686aa192bf8cd2c4b398b5480"
     },
@@ -3091,7 +3125,7 @@
       "checksum": "e3293f6b22b641db2a78a50f8c24d8eb"
     },
     "packrat/packrat.lock": {
-      "checksum": "6d7fa167f14526aff78cf1fd3eb9ebbc"
+      "checksum": "a74cc28cc84108032b7026430c9d9fab"
     },
     "RStudio1.png": {
       "checksum": "288da77036023512c0adbf27de9fe9c2"

--- a/flexdashboard/manifest.json
+++ b/flexdashboard/manifest.json
@@ -11,8 +11,8 @@
   },
   "packages": {
     "BH": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -37,8 +37,8 @@
       }
     },
     "DT": {
-      "Source": "CRAN",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -47,29 +47,29 @@
         "Package": "DT",
         "Type": "Package",
         "Title": "A Wrapper of the JavaScript Library 'DataTables'",
-        "Version": "0.9",
+        "Version": "0.11",
         "Authors@R": "c(\n    person(\"Yihui\", \"Xie\", email = \"xie@yihui.name\", role = c(\"aut\", \"cre\")),\n    person(\"Joe\", \"Cheng\", role = \"aut\"),\n    person(\"Xianying\", \"Tan\", role = \"aut\"),\n    person(\"JJ\", \"Allaire\", role = \"ctb\"),\n    person(\"Maximilian\", \"Girlich\", role = \"ctb\"),\n    person(\"Greg\", \"Freedman Ellis\", role = \"ctb\"),\n    person(\"Johannes\", \"Rauh\", role = \"ctb\"),\n    person(\"jQuery contributors\", role = c(\"ctb\", \"cph\"), comment = \"jQuery in htmlwidgets/lib\"),\n    person(\"SpryMedia Limited\", role = c(\"ctb\", \"cph\"), comment = \"DataTables in htmlwidgets/lib\"),\n    person(\"Brian\", \"Reavis\", role = c(\"ctb\", \"cph\"), comment = \"selectize.js in htmlwidgets/lib\"),\n    person(\"Leon\", \"Gersen\", role = c(\"ctb\", \"cph\"), comment = \"noUiSlider in htmlwidgets/lib\"),\n    person(\"Bartek\", \"Szopka\", role = c(\"ctb\", \"cph\"), comment = \"jquery.highlight.js in htmlwidgets/lib\"),\n    person(\"RStudio Inc\", role = \"cph\")\n    )",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Description": "Data objects in R can be rendered as HTML tables using the\n    JavaScript library 'DataTables' (typically via R Markdown or Shiny). The\n    'DataTables' library has been included in this R package. The package name\n    'DT' is an abbreviation of 'DataTables'.",
-        "URL": "https://rstudio.github.io/DT",
+        "URL": "https://github.com/rstudio/DT",
         "BugReports": "https://github.com/rstudio/DT/issues",
         "License": "GPL-3 | file LICENSE",
         "Imports": "htmltools (>= 0.3.6), htmlwidgets (>= 1.3), jsonlite (>=\n0.9.16), magrittr, crosstalk, promises",
-        "Suggests": "knitr (>= 1.8), rmarkdown, shiny (>= 1.1.0)",
+        "Suggests": "knitr (>= 1.8), rmarkdown, shiny (>= 1.2.0)",
         "VignetteBuilder": "knitr",
-        "RoxygenNote": "6.1.1",
+        "RoxygenNote": "7.0.2",
         "Encoding": "UTF-8",
         "NeedsCompilation": "no",
-        "Packaged": "2019-09-17 04:12:43 UTC; yihui",
+        "Packaged": "2019-12-19 17:35:58 UTC; yihui",
         "Author": "Yihui Xie [aut, cre],\n  Joe Cheng [aut],\n  Xianying Tan [aut],\n  JJ Allaire [ctb],\n  Maximilian Girlich [ctb],\n  Greg Freedman Ellis [ctb],\n  Johannes Rauh [ctb],\n  jQuery contributors [ctb, cph] (jQuery in htmlwidgets/lib),\n  SpryMedia Limited [ctb, cph] (DataTables in htmlwidgets/lib),\n  Brian Reavis [ctb, cph] (selectize.js in htmlwidgets/lib),\n  Leon Gersen [ctb, cph] (noUiSlider in htmlwidgets/lib),\n  Bartek Szopka [ctb, cph] (jquery.highlight.js in htmlwidgets/lib),\n  RStudio Inc [cph]",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-09-17 09:10:10 UTC",
-        "Built": "R 3.6.0; ; 2019-10-31 15:53:47 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-12-19 18:50:09 UTC",
+        "Built": "R 3.6.2; ; 2020-01-06 15:00:50 UTC; unix"
       }
     },
     "MASS": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -102,8 +102,8 @@
       }
     },
     "Matrix": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -138,8 +138,8 @@
       }
     },
     "R6": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -168,8 +168,8 @@
       }
     },
     "RColorBrewer": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -194,8 +194,8 @@
       }
     },
     "Rcpp": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -226,8 +226,8 @@
       }
     },
     "askpass": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -258,8 +258,8 @@
       }
     },
     "assertthat": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -286,8 +286,8 @@
       }
     },
     "backports": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -317,8 +317,8 @@
       }
     },
     "base64enc": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -343,8 +343,8 @@
       }
     },
     "callr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -375,8 +375,8 @@
       }
     },
     "cli": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -406,8 +406,8 @@
       }
     },
     "colorspace": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -439,8 +439,8 @@
       }
     },
     "crayon": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -470,8 +470,8 @@
       }
     },
     "crosstalk": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -499,8 +499,8 @@
       }
     },
     "curl": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -534,7 +534,7 @@
     },
     "digest": {
       "Source": "CRAN",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -562,8 +562,8 @@
       }
     },
     "dplyr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -592,12 +592,12 @@
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2019-07-04 15:50:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-05 17:06:48 UTC; unix"
+        "Built": "R 3.6.2; x86_64-pc-linux-gnu; 2020-01-09 17:40:05 UTC; unix"
       }
     },
     "ellipsis": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -627,8 +627,8 @@
       }
     },
     "evaluate": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -658,8 +658,8 @@
       }
     },
     "fansi": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -727,8 +727,8 @@
       }
     },
     "flexdashboard": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -759,8 +759,8 @@
       }
     },
     "fs": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -796,8 +796,8 @@
       }
     },
     "ggplot2": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -830,8 +830,8 @@
       }
     },
     "glue": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -863,8 +863,8 @@
       }
     },
     "gridExtra": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -892,8 +892,8 @@
       }
     },
     "gtable": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -924,8 +924,8 @@
       }
     },
     "highr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -996,8 +996,8 @@
       }
     },
     "htmlwidgets": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1028,8 +1028,8 @@
       }
     },
     "httpuv": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1061,8 +1061,8 @@
       }
     },
     "httr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1092,8 +1092,8 @@
       }
     },
     "jsonlite": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1121,8 +1121,8 @@
       }
     },
     "knitr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1155,8 +1155,8 @@
       }
     },
     "labeling": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1186,7 +1186,7 @@
     },
     "later": {
       "Source": "CRAN",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1216,8 +1216,8 @@
       }
     },
     "lattice": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1249,8 +1249,8 @@
       }
     },
     "lazyeval": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1278,8 +1278,8 @@
       }
     },
     "leaflet": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1288,30 +1288,63 @@
         "Package": "leaflet",
         "Type": "Package",
         "Title": "Create Interactive Web Maps with the JavaScript 'Leaflet'\nLibrary",
-        "Version": "2.0.2",
-        "Authors@R": "c(\n      person(\"Joe\", \"Cheng\", email = \"joe@rstudio.com\", role = c(\"aut\", \"cre\")),\n      person(\"Bhaskar\", \"Karambelkar\", role = c(\"aut\")),\n      person(\"Yihui\", \"Xie\", role = c(\"aut\")),\n      person(\"Hadley\", \"Wickham\", role = c(\"ctb\")),\n      person(\"Kenton\", \"Russell\", role = c(\"ctb\")),\n      person(\"Kent\", \"Johnson\", role = c(\"ctb\")),\n      person(\"Barret\", \"Schloerke\", role = c(\"ctb\")),\n      person(\"jQuery Foundation and contributors\", role = c(\"ctb\", \"cph\"), comment = \"jQuery library\"),\n      person(\"Vladimir\", \"Agafonkin\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet library\"),\n      person(\"CloudMade\", role = c(\"cph\"), comment = \"Leaflet library\"),\n      person(\"Leaflet contributors\", role = c(\"ctb\"), comment = \"Leaflet library\"),\n      person(\"Leaflet Providers contributors\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet Providers plugin\"),\n      person(\"Brandon Copeland\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-measure plugin\"),\n      person(\"Joerg Dietrich\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.Terminator plugin\"),\n      person(\"Benjamin Becquet\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.MagnifyingGlass plugin\"),\n      person(\"Norkart AS\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.MiniMap plugin\"),\n      person(\"L. Voogdt\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.awesome-markers plugin\"),\n      person(\"Daniel Montague\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.EasyButton plugin\"),\n      person(\"Kartena AB\", role = c(\"ctb\", \"cph\"), comment = \"Proj4Leaflet plugin\"),\n      person(\"Robert Kajic\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-locationfilter plugin\"),\n      person(\"Mapbox\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-omnivore plugin\"),\n      person(\"Michael Bostock\", role = c(\"ctb\", \"cph\"), comment = \"topojson\"),\n      person(\"RStudio\", role = c(\"cph\"))\n    )",
-        "Maintainer": "Joe Cheng <joe@rstudio.com>",
+        "Version": "2.0.3",
+        "Authors@R": "c(\n      person(\"Joe\", \"Cheng\", email = \"joe@rstudio.com\", role = c(\"aut\", \"cre\")),\n      person(\"Bhaskar\", \"Karambelkar\", role = c(\"aut\")),\n      person(\"Yihui\", \"Xie\", role = c(\"aut\")),\n      person(\"Hadley\", \"Wickham\", role = c(\"ctb\")),\n      person(\"Kenton\", \"Russell\", role = c(\"ctb\")),\n      person(\"Kent\", \"Johnson\", role = c(\"ctb\")),\n      person(\"Barret\", \"Schloerke\", role = c(\"ctb\")),\n      person(\"jQuery Foundation and contributors\", role = c(\"ctb\", \"cph\"), comment = \"jQuery library\"),\n      person(\"Vladimir\", \"Agafonkin\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet library\"),\n      person(\"CloudMade\", role = c(\"cph\"), comment = \"Leaflet library\"),\n      person(\"Leaflet contributors\", role = c(\"ctb\"), comment = \"Leaflet library\"),\n      person(\"Brandon Copeland\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-measure plugin\"),\n      person(\"Joerg Dietrich\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.Terminator plugin\"),\n      person(\"Benjamin Becquet\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.MagnifyingGlass plugin\"),\n      person(\"Norkart AS\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.MiniMap plugin\"),\n      person(\"L. Voogdt\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.awesome-markers plugin\"),\n      person(\"Daniel Montague\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.EasyButton plugin\"),\n      person(\"Kartena AB\", role = c(\"ctb\", \"cph\"), comment = \"Proj4Leaflet plugin\"),\n      person(\"Robert Kajic\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-locationfilter plugin\"),\n      person(\"Mapbox\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-omnivore plugin\"),\n      person(\"Michael Bostock\", role = c(\"ctb\", \"cph\"), comment = \"topojson\"),\n      person(\"RStudio\", role = c(\"cph\"))\n    )",
         "Description": "Create and customize interactive maps using the 'Leaflet'\n    JavaScript library and the 'htmlwidgets' package. These maps can be used\n    directly from the R console, from 'RStudio', in Shiny applications and R Markdown\n    documents.",
         "License": "GPL-3",
         "URL": "http://rstudio.github.io/leaflet/",
         "BugReports": "https://github.com/rstudio/leaflet/issues",
         "Depends": "R (>= 3.1.0)",
-        "Imports": "base64enc, crosstalk, htmlwidgets, htmltools, magrittr,\nmarkdown, methods, png, RColorBrewer, raster, scales (>=\n1.0.0), sp, stats, viridis (>= 0.5.1)",
-        "Suggests": "knitr, maps, sf, shiny, testit (>= 0.4), rgdal, rgeos, R6,\nRJSONIO, purrr, testthat",
-        "RoxygenNote": "6.1.0",
+        "Imports": "base64enc, crosstalk, htmlwidgets, htmltools, magrittr,\nmarkdown, methods, png, RColorBrewer, raster, scales (>=\n1.0.0), sp, stats, viridis (>= 0.5.1), leaflet.providers (>=\n1.8.0)",
+        "Suggests": "knitr, maps, sf, shiny, rgdal, rgeos, R6, RJSONIO, purrr,\ntestthat",
+        "RoxygenNote": "6.1.1",
         "Encoding": "UTF-8",
         "LazyData": "true",
         "NeedsCompilation": "no",
-        "Packaged": "2018-08-24 20:03:55 UTC; barret",
-        "Author": "Joe Cheng [aut, cre],\n  Bhaskar Karambelkar [aut],\n  Yihui Xie [aut],\n  Hadley Wickham [ctb],\n  Kenton Russell [ctb],\n  Kent Johnson [ctb],\n  Barret Schloerke [ctb],\n  jQuery Foundation and contributors [ctb, cph] (jQuery library),\n  Vladimir Agafonkin [ctb, cph] (Leaflet library),\n  CloudMade [cph] (Leaflet library),\n  Leaflet contributors [ctb] (Leaflet library),\n  Leaflet Providers contributors [ctb, cph] (Leaflet Providers plugin),\n  Brandon Copeland [ctb, cph] (leaflet-measure plugin),\n  Joerg Dietrich [ctb, cph] (Leaflet.Terminator plugin),\n  Benjamin Becquet [ctb, cph] (Leaflet.MagnifyingGlass plugin),\n  Norkart AS [ctb, cph] (Leaflet.MiniMap plugin),\n  L. Voogdt [ctb, cph] (Leaflet.awesome-markers plugin),\n  Daniel Montague [ctb, cph] (Leaflet.EasyButton plugin),\n  Kartena AB [ctb, cph] (Proj4Leaflet plugin),\n  Robert Kajic [ctb, cph] (leaflet-locationfilter plugin),\n  Mapbox [ctb, cph] (leaflet-omnivore plugin),\n  Michael Bostock [ctb, cph] (topojson),\n  RStudio [cph]",
+        "Packaged": "2019-11-14 18:00:03 UTC; barret",
+        "Author": "Joe Cheng [aut, cre],\n  Bhaskar Karambelkar [aut],\n  Yihui Xie [aut],\n  Hadley Wickham [ctb],\n  Kenton Russell [ctb],\n  Kent Johnson [ctb],\n  Barret Schloerke [ctb],\n  jQuery Foundation and contributors [ctb, cph] (jQuery library),\n  Vladimir Agafonkin [ctb, cph] (Leaflet library),\n  CloudMade [cph] (Leaflet library),\n  Leaflet contributors [ctb] (Leaflet library),\n  Brandon Copeland [ctb, cph] (leaflet-measure plugin),\n  Joerg Dietrich [ctb, cph] (Leaflet.Terminator plugin),\n  Benjamin Becquet [ctb, cph] (Leaflet.MagnifyingGlass plugin),\n  Norkart AS [ctb, cph] (Leaflet.MiniMap plugin),\n  L. Voogdt [ctb, cph] (Leaflet.awesome-markers plugin),\n  Daniel Montague [ctb, cph] (Leaflet.EasyButton plugin),\n  Kartena AB [ctb, cph] (Proj4Leaflet plugin),\n  Robert Kajic [ctb, cph] (leaflet-locationfilter plugin),\n  Mapbox [ctb, cph] (leaflet-omnivore plugin),\n  Michael Bostock [ctb, cph] (topojson),\n  RStudio [cph]",
+        "Maintainer": "Joe Cheng <joe@rstudio.com>",
         "Repository": "RSPM",
-        "Date/Publication": "2018-08-27 14:12:16 UTC",
-        "Built": "R 3.6.1; ; 2019-09-21 13:25:53 UTC; unix"
+        "Date/Publication": "2019-11-16 05:50:05 UTC",
+        "Built": "R 3.6.1; ; 2019-11-18 12:10:30 UTC; unix"
+      }
+    },
+    "leaflet.providers": {
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "leaflet.providers",
+        "Type": "Package",
+        "Title": "Leaflet Providers",
+        "Version": "1.9.0",
+        "Authors@R": "c(\n      person(\"Leslie\", \"Huang\", email = \"lesliehuang@nyu.edu\", role = c(\"aut\")),\n      person(\"Barret\", \"Schloerke\", email = \"barret@rstudio.com\", role = c(\"ctb\", \"cre\"),\n        comment = c(ORCID = \"0000-0001-9986-114X\")),\n      person(\"Leaflet Providers contributors\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet Providers plugin\"),\n      person(\"RStudio\", role = c(\"cph\", \"fnd\"))\n    )",
+        "Description": "Contains third-party map tile provider information from\n    'Leaflet.js', <https://github.com/leaflet-extras/leaflet-providers>, to be\n    used with the 'leaflet' R package. Additionally, 'leaflet.providers'\n    enables users to retrieve up-to-date provider information between package\n    updates.",
+        "License": "BSD_2_clause + file LICENSE",
+        "Encoding": "UTF-8",
+        "LazyData": "true",
+        "Depends": "R (>= 2.10)",
+        "Suggests": "V8, jsonlite, testthat (>= 2.1.0)",
+        "Language": "en-US",
+        "RoxygenNote": "6.1.1",
+        "URL": "https://github.com/rstudio/leaflet.providers",
+        "BugReports": "https://github.com/rstudio/leaflet.providers/issues",
+        "Collate": "'providers_data.R' 'get_current_providers.R'",
+        "NeedsCompilation": "no",
+        "Packaged": "2019-11-08 22:12:22 UTC; barret",
+        "Author": "Leslie Huang [aut],\n  Barret Schloerke [ctb, cre] (<https://orcid.org/0000-0001-9986-114X>),\n  Leaflet Providers contributors [ctb, cph] (Leaflet Providers plugin),\n  RStudio [cph, fnd]",
+        "Maintainer": "Barret Schloerke <barret@rstudio.com>",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-11-09 23:40:09 UTC",
+        "Built": "R 3.6.1; ; 2019-11-11 20:38:55 UTC; unix"
       }
     },
     "magrittr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1337,8 +1370,8 @@
       }
     },
     "markdown": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1369,8 +1402,8 @@
       }
     },
     "metricsgraphics": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1402,8 +1435,8 @@
       }
     },
     "mgcv": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1431,8 +1464,8 @@
       }
     },
     "mime": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1461,8 +1494,8 @@
       }
     },
     "munsell": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1489,8 +1522,8 @@
       }
     },
     "nlme": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1522,8 +1555,8 @@
       }
     },
     "openssl": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1554,8 +1587,8 @@
       }
     },
     "pillar": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1585,17 +1618,17 @@
       }
     },
     "pins": {
-      "Source": "github",
-      "Repository": null,
-      "GithubRepo": "pins",
-      "GithubUsername": "rstudio",
-      "GithubRef": "master",
-      "GithubSha1": "e826fea0281e796ef5359a708ffc46d80b546a7c",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
       "description": {
         "Package": "pins",
         "Type": "Package",
         "Title": "Pin, Discover and Share Resources",
-        "Version": "0.2.0.0004",
+        "Version": "0.3.0",
         "Authors@R": "c(\n    person(\"Javier\", \"Luraschi\", email = \"javier@rstudio.com\", role = c(\"aut\", \"cre\")),\n    person(family = \"RStudio\", role = c(\"cph\"))\n    )",
         "Maintainer": "Javier Luraschi <javier@rstudio.com>",
         "Description": "Pin remote resources into a local cache to work offline,\n  improve speed and avoid recomputing; discover and share resources\n  in local folders, 'GitHub', 'Kaggle' or 'RStudio Connect'. Resources can \n  be anything from 'CSV', 'JSON', or image files to arbitrary R objects.",
@@ -1604,30 +1637,22 @@
         "LazyData": "true",
         "RoxygenNote": "6.1.1",
         "Depends": "R (>= 3.2.0)",
-        "Imports": "base64enc, httr, jsonlite, magrittr, mime, openssl, rappdirs,\nwithr, yaml, zip",
+        "Imports": "base64enc, crayon, httr, jsonlite, magrittr, mime, openssl,\nrappdirs, withr, yaml, zip",
         "Suggests": "knitr, rmarkdown, R6, testthat",
         "VignetteBuilder": "knitr",
         "URL": "https://github.com/rstudio/pins",
         "BugReports": "https://github.com/rstudio/pins/issues",
-        "RemoteType": "github",
-        "RemoteHost": "api.github.com",
-        "RemoteRepo": "pins",
-        "RemoteUsername": "rstudio",
-        "RemoteRef": "master",
-        "RemoteSha": "e826fea0281e796ef5359a708ffc46d80b546a7c",
-        "GithubRepo": "pins",
-        "GithubUsername": "rstudio",
-        "GithubRef": "master",
-        "GithubSHA1": "e826fea0281e796ef5359a708ffc46d80b546a7c",
         "NeedsCompilation": "no",
-        "Packaged": "2019-11-08 01:28:59 UTC; james",
+        "Packaged": "2019-11-26 12:12:46 UTC; javierluraschi",
         "Author": "Javier Luraschi [aut, cre],\n  RStudio [cph]",
-        "Built": "R 3.6.0; ; 2019-11-08 01:29:00 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-11-26 12:40:02 UTC",
+        "Built": "R 3.6.1; ; 2019-12-02 13:02:20 UTC; unix"
       }
     },
     "pkgconfig": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1654,8 +1679,8 @@
       }
     },
     "plogr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1684,8 +1709,8 @@
       }
     },
     "plyr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1716,8 +1741,8 @@
       }
     },
     "png": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1742,8 +1767,8 @@
       }
     },
     "processx": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1773,7 +1798,7 @@
     },
     "promises": {
       "Source": "CRAN",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1805,8 +1830,8 @@
       }
     },
     "ps": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1836,8 +1861,8 @@
       }
     },
     "purrr": {
-      "Source": "CRAN",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1862,14 +1887,14 @@
         "Packaged": "2019-10-17 08:02:23 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  RStudio [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-10-18 12:40:05 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-11-08 21:28:40 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-10-21 10:48:05 UTC; unix"
       }
     },
     "rappdirs": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1899,8 +1924,8 @@
       }
     },
     "raster": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1932,8 +1957,8 @@
       }
     },
     "rematch2": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1962,8 +1987,8 @@
       }
     },
     "reshape2": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1993,8 +2018,8 @@
       }
     },
     "rlang": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2025,8 +2050,8 @@
       }
     },
     "rmarkdown": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2058,8 +2083,8 @@
       }
     },
     "rprojroot": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2091,8 +2116,8 @@
       }
     },
     "scales": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2123,44 +2148,35 @@
       }
     },
     "shiny": {
-      "Source": "github",
-      "Repository": null,
-      "GithubRepo": "shiny",
-      "GithubUsername": "rstudio",
-      "GithubRef": "master",
-      "GithubSha1": "e07c7483a79cc641d464cd7496872a28eedbe4a4",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
       "description": {
         "Package": "shiny",
         "Type": "Package",
         "Title": "Web Application Framework for R",
-        "Version": "1.4.0.9001",
+        "Version": "1.4.0",
         "Authors@R": "c(\n    person(\"Winston\", \"Chang\", role = c(\"aut\", \"cre\"), email = \"winston@rstudio.com\"),\n    person(\"Joe\", \"Cheng\", role = \"aut\", email = \"joe@rstudio.com\"),\n    person(\"JJ\", \"Allaire\", role = \"aut\", email = \"jj@rstudio.com\"),\n    person(\"Yihui\", \"Xie\", role = \"aut\", email = \"yihui@rstudio.com\"),\n    person(\"Jonathan\", \"McPherson\", role = \"aut\", email = \"jonathan@rstudio.com\"),\n    person(family = \"RStudio\", role = \"cph\"),\n    person(family = \"jQuery Foundation\", role = \"cph\",\n    comment = \"jQuery library and jQuery UI library\"),\n    person(family = \"jQuery contributors\", role = c(\"ctb\", \"cph\"),\n    comment = \"jQuery library; authors listed in inst/www/shared/jquery-AUTHORS.txt\"),\n    person(family = \"jQuery UI contributors\", role = c(\"ctb\", \"cph\"),\n    comment = \"jQuery UI library; authors listed in inst/www/shared/jqueryui/AUTHORS.txt\"),\n    person(\"Mark\", \"Otto\", role = \"ctb\",\n    comment = \"Bootstrap library\"),\n    person(\"Jacob\", \"Thornton\", role = \"ctb\",\n    comment = \"Bootstrap library\"),\n    person(family = \"Bootstrap contributors\", role = \"ctb\",\n    comment = \"Bootstrap library\"),\n    person(family = \"Twitter, Inc\", role = \"cph\",\n    comment = \"Bootstrap library\"),\n    person(\"Alexander\", \"Farkas\", role = c(\"ctb\", \"cph\"),\n    comment = \"html5shiv library\"),\n    person(\"Scott\", \"Jehl\", role = c(\"ctb\", \"cph\"),\n    comment = \"Respond.js library\"),\n    person(\"Stefan\", \"Petre\", role = c(\"ctb\", \"cph\"),\n    comment = \"Bootstrap-datepicker library\"),\n    person(\"Andrew\", \"Rowls\", role = c(\"ctb\", \"cph\"),\n    comment = \"Bootstrap-datepicker library\"),\n    person(\"Dave\", \"Gandy\", role = c(\"ctb\", \"cph\"),\n    comment = \"Font-Awesome font\"),\n    person(\"Brian\", \"Reavis\", role = c(\"ctb\", \"cph\"),\n    comment = \"selectize.js library\"),\n    person(\"Kristopher Michael\", \"Kowal\", role = c(\"ctb\", \"cph\"),\n    comment = \"es5-shim library\"),\n    person(family = \"es5-shim contributors\", role = c(\"ctb\", \"cph\"),\n    comment = \"es5-shim library\"),\n    person(\"Denis\", \"Ineshin\", role = c(\"ctb\", \"cph\"),\n    comment = \"ion.rangeSlider library\"),\n    person(\"Sami\", \"Samhuri\", role = c(\"ctb\", \"cph\"),\n    comment = \"Javascript strftime library\"),\n    person(family = \"SpryMedia Limited\", role = c(\"ctb\", \"cph\"),\n    comment = \"DataTables library\"),\n    person(\"John\", \"Fraser\", role = c(\"ctb\", \"cph\"),\n    comment = \"showdown.js library\"),\n    person(\"John\", \"Gruber\", role = c(\"ctb\", \"cph\"),\n    comment = \"showdown.js library\"),\n    person(\"Ivan\", \"Sagalaev\", role = c(\"ctb\", \"cph\"),\n    comment = \"highlight.js library\"),\n    person(family = \"R Core Team\", role = c(\"ctb\", \"cph\"),\n    comment = \"tar implementation from R\")\n    )",
         "Description": "Makes it incredibly easy to build interactive web\n    applications with R. Automatic \"reactive\" binding between inputs and\n    outputs and extensive prebuilt widgets make it possible to build\n    beautiful, responsive, and powerful applications with minimal effort.",
         "License": "GPL-3 | file LICENSE",
         "Depends": "R (>= 3.0.2), methods",
-        "Imports": "utils, grDevices, httpuv (>= 1.5.2), mime (>= 0.3), jsonlite\n(>= 0.9.16), xtable, digest, htmltools (>= 0.4.0), R6 (>= 2.0),\nsourcetools, later (>= 1.0.0), promises (>= 1.1.0), tools,\ncrayon, rlang (>= 0.4.0), fastmap (>= 1.0.0), withr",
-        "Suggests": "datasets, Cairo (>= 1.5-5), testthat (>= 2.1.1), knitr (>=\n1.6), markdown, rmarkdown, ggplot2, reactlog (>= 1.0.0),\nmagrittr, shinytest, yaml, future, dygraphs",
+        "Imports": "utils, grDevices, httpuv (>= 1.5.2), mime (>= 0.3), jsonlite\n(>= 0.9.16), xtable, digest, htmltools (>= 0.4.0), R6 (>= 2.0),\nsourcetools, later (>= 1.0.0), promises (>= 1.1.0), tools,\ncrayon, rlang (>= 0.4.0), fastmap (>= 1.0.0)",
+        "Suggests": "datasets, Cairo (>= 1.5-5), testthat (>= 2.1.1), knitr (>=\n1.6), markdown, rmarkdown, ggplot2, reactlog (>= 1.0.0),\nmagrittr, yaml",
         "URL": "http://shiny.rstudio.com",
         "BugReports": "https://github.com/rstudio/shiny/issues",
-        "Collate": "'app.R' 'bookmark-state-local.R' 'stack.R' 'bookmark-state.R'\n'bootstrap-deprecated.R' 'bootstrap-layout.R' 'globals.R'\n'conditions.R' 'map.R' 'utils.R' 'bootstrap.R'\n'cache-context.R' 'cache-disk.R' 'cache-memory.R'\n'cache-utils.R' 'diagnose.R' 'fileupload.R' 'font-awesome.R'\n'graph.R' 'reactives.R' 'reactive-domains.R' 'history.R'\n'hooks.R' 'html-deps.R' 'htmltools.R' 'image-interact-opts.R'\n'image-interact.R' 'imageutils.R' 'input-action.R'\n'input-checkbox.R' 'input-checkboxgroup.R' 'input-date.R'\n'input-daterange.R' 'input-file.R' 'input-numeric.R'\n'input-password.R' 'input-radiobuttons.R' 'input-select.R'\n'input-slider.R' 'input-submit.R' 'input-text.R'\n'input-textarea.R' 'input-utils.R' 'insert-tab.R' 'insert-ui.R'\n'jqueryui.R' 'middleware-shiny.R' 'middleware.R' 'timer.R'\n'mock-session.R' 'modal.R' 'modules.R' 'notifications.R'\n'priorityqueue.R' 'progress.R' 'react.R' 'render-cached-plot.R'\n'render-plot.R' 'render-table.R' 'run-url.R' 'serializers.R'\n'server-input-handlers.R' 'server.R' 'shiny-options.R'\n'shiny.R' 'shinyui.R' 'shinywrappers.R' 'showcase.R'\n'snapshot.R' 'tar.R' 'test-export.R' 'test-module.R' 'test.R'\n'update-input.R'",
-        "RoxygenNote": "7.0.2",
+        "Collate": "'app.R' 'bookmark-state-local.R' 'stack.R' 'bookmark-state.R'\n'bootstrap-deprecated.R' 'bootstrap-layout.R' 'globals.R'\n'conditions.R' 'map.R' 'utils.R' 'bootstrap.R'\n'cache-context.R' 'cache-disk.R' 'cache-memory.R'\n'cache-utils.R' 'diagnose.R' 'fileupload.R' 'font-awesome.R'\n'graph.R' 'reactives.R' 'reactive-domains.R' 'history.R'\n'hooks.R' 'html-deps.R' 'htmltools.R' 'image-interact-opts.R'\n'image-interact.R' 'imageutils.R' 'input-action.R'\n'input-checkbox.R' 'input-checkboxgroup.R' 'input-date.R'\n'input-daterange.R' 'input-file.R' 'input-numeric.R'\n'input-password.R' 'input-radiobuttons.R' 'input-select.R'\n'input-slider.R' 'input-submit.R' 'input-text.R'\n'input-textarea.R' 'input-utils.R' 'insert-tab.R' 'insert-ui.R'\n'jqueryui.R' 'middleware-shiny.R' 'middleware.R' 'modal.R'\n'modules.R' 'notifications.R' 'priorityqueue.R' 'progress.R'\n'react.R' 'render-cached-plot.R' 'render-plot.R'\n'render-table.R' 'run-url.R' 'serializers.R'\n'server-input-handlers.R' 'server.R' 'shiny-options.R'\n'shiny.R' 'shinyui.R' 'shinywrappers.R' 'showcase.R'\n'snapshot.R' 'tar.R' 'test-export.R' 'timer.R' 'update-input.R'",
+        "RoxygenNote": "6.1.1",
         "Encoding": "UTF-8",
-        "Roxygen": "list(markdown = TRUE)",
-        "RemoteType": "github",
-        "RemoteHost": "api.github.com",
-        "RemoteRepo": "shiny",
-        "RemoteUsername": "rstudio",
-        "RemoteRef": "master",
-        "RemoteSha": "e07c7483a79cc641d464cd7496872a28eedbe4a4",
-        "GithubRepo": "shiny",
-        "GithubUsername": "rstudio",
-        "GithubRef": "master",
-        "GithubSHA1": "e07c7483a79cc641d464cd7496872a28eedbe4a4",
         "NeedsCompilation": "no",
-        "Packaged": "2019-12-04 21:10:14 UTC; james",
+        "Packaged": "2019-10-08 16:21:27 UTC; winston",
         "Author": "Winston Chang [aut, cre],\n  Joe Cheng [aut],\n  JJ Allaire [aut],\n  Yihui Xie [aut],\n  Jonathan McPherson [aut],\n  RStudio [cph],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/www/shared/jqueryui/AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Alexander Farkas [ctb, cph] (html5shiv library),\n  Scott Jehl [ctb, cph] (Respond.js library),\n  Stefan Petre [ctb, cph] (Bootstrap-datepicker library),\n  Andrew Rowls [ctb, cph] (Bootstrap-datepicker library),\n  Dave Gandy [ctb, cph] (Font-Awesome font),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Kristopher Michael Kowal [ctb, cph] (es5-shim library),\n  es5-shim contributors [ctb, cph] (es5-shim library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library),\n  SpryMedia Limited [ctb, cph] (DataTables library),\n  John Fraser [ctb, cph] (showdown.js library),\n  John Gruber [ctb, cph] (showdown.js library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  R Core Team [ctb, cph] (tar implementation from R)",
         "Maintainer": "Winston Chang <winston@rstudio.com>",
-        "Built": "R 3.6.0; ; 2019-12-04 21:10:17 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-10-10 12:50:02 UTC",
+        "Built": "R 3.6.2; ; 2019-12-27 20:42:36 UTC; unix"
       }
     },
     "shinymeta": {
@@ -2206,8 +2222,8 @@
       }
     },
     "sourcetools": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2235,8 +2251,8 @@
       }
     },
     "sp": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2265,8 +2281,8 @@
       }
     },
     "stringi": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2298,8 +2314,8 @@
       }
     },
     "stringr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2330,8 +2346,8 @@
       }
     },
     "styler": {
-      "Source": "CRAN",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2357,14 +2373,14 @@
         "Packaged": "2019-10-17 18:22:11 UTC; lorenz",
         "Author": "Kirill Müller [aut],\n  Lorenz Walthert [cre, aut]",
         "Maintainer": "Lorenz Walthert <lorenz.walthert@icloud.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-10-17 20:20:02 UTC",
-        "Built": "R 3.6.0; ; 2019-11-08 21:28:48 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-10-21 10:55:33 UTC; unix"
       }
     },
     "sys": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2394,8 +2410,8 @@
       }
     },
     "tibble": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2427,8 +2443,8 @@
       }
     },
     "tidyselect": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2458,8 +2474,8 @@
       }
     },
     "tinytex": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2489,8 +2505,8 @@
       }
     },
     "utf8": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2519,8 +2535,8 @@
       }
     },
     "vctrs": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2552,8 +2568,8 @@
       }
     },
     "viridis": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2585,8 +2601,8 @@
       }
     },
     "viridisLite": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2616,8 +2632,8 @@
       }
     },
     "withr": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2650,7 +2666,7 @@
     },
     "xfun": {
       "Source": "CRAN",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2681,8 +2697,8 @@
       }
     },
     "xtable": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2711,8 +2727,8 @@
       }
     },
     "yaml": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2739,8 +2755,8 @@
       }
     },
     "zeallot": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2769,8 +2785,8 @@
       }
     },
     "zip": {
-      "Source": "RSPM",
-      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "Source": "latest",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/latest",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2844,10 +2860,10 @@
       "checksum": "db95b45f9e17608bedb6e3ebc8f7434c"
     },
     "packrat/desc/dplyr": {
-      "checksum": "0654cfd2c84e841c51027d8240119875"
+      "checksum": "4970487a14f6953e04aaf0bc0861aa16"
     },
     "packrat/desc/DT": {
-      "checksum": "0160e099f0199076be97cd0b1d40a5be"
+      "checksum": "e239c8bd258195a2d6267757d99bf9cc"
     },
     "packrat/desc/ellipsis": {
       "checksum": "f8940115c3de14708d5d809ae710a122"
@@ -2913,7 +2929,10 @@
       "checksum": "8f68250532bafe421c42056ee807493b"
     },
     "packrat/desc/leaflet": {
-      "checksum": "89ac4bd5e5020e7e791f5ad69604e9dd"
+      "checksum": "8626aae5c568509c3c0656cdc996cd08"
+    },
+    "packrat/desc/leaflet.providers": {
+      "checksum": "6e0a71533cc5d0d14ba3b159300746e8"
     },
     "packrat/desc/magrittr": {
       "checksum": "dcce0bdbd647711dae3d552ebbf280aa"
@@ -2949,7 +2968,7 @@
       "checksum": "b3ba10f4887f52e13532e5469b875af4"
     },
     "packrat/desc/pins": {
-      "checksum": "0b70570f2108b49e713a4b6ccd6b2106"
+      "checksum": "c01f791afc06e84adfb4456acb44ad4b"
     },
     "packrat/desc/pkgconfig": {
       "checksum": "1d82067bb8c76ebb7ed1513fd287b138"
@@ -2973,7 +2992,7 @@
       "checksum": "1c84fa678ea6c67537dd47074a43f340"
     },
     "packrat/desc/purrr": {
-      "checksum": "5ebea74629afd41c612756716d442050"
+      "checksum": "39b16becf00febf6e00858d1cef855c1"
     },
     "packrat/desc/R6": {
       "checksum": "77d6a69ea384a72bb1886dffe4cafdf1"
@@ -3009,7 +3028,7 @@
       "checksum": "02dd17cd0e15fdf6aaa64f09f39305cf"
     },
     "packrat/desc/shiny": {
-      "checksum": "ae9028e249107ae8e103e8f3840af5a3"
+      "checksum": "71028b0db6da338537425e45f4e96ce3"
     },
     "packrat/desc/shinymeta": {
       "checksum": "23e8bfe686aa192bf8cd2c4b398b5480"
@@ -3027,7 +3046,7 @@
       "checksum": "b50ca25c58190e25272b7c7319b1b15f"
     },
     "packrat/desc/styler": {
-      "checksum": "0cbf9f137f9d784887f10250602753ed"
+      "checksum": "95fc27ea3e3601312694221e968ad854"
     },
     "packrat/desc/sys": {
       "checksum": "702075f86d37f9daf353a7f1cb153768"
@@ -3072,7 +3091,7 @@
       "checksum": "e3293f6b22b641db2a78a50f8c24d8eb"
     },
     "packrat/packrat.lock": {
-      "checksum": "09132b3263cc30e02a413b4b3af4d79e"
+      "checksum": "6d7fa167f14526aff78cf1fd3eb9ebbc"
     },
     "RStudio1.png": {
       "checksum": "288da77036023512c0adbf27de9fe9c2"

--- a/flexdashboard/manifest.json
+++ b/flexdashboard/manifest.json
@@ -11,8 +11,8 @@
   },
   "packages": {
     "BH": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -32,12 +32,13 @@
         "Packaged": "2019-01-07 12:00:43.681885 UTC; edd",
         "Repository": "RSPM",
         "Date/Publication": "2019-01-07 19:50:25 UTC",
-        "Built": "R 3.6.1; ; 2019-09-10 15:06:41 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.2; ; 2019-12-27 20:36:13 UTC; unix"
       }
     },
     "DT": {
       "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -46,11 +47,11 @@
         "Package": "DT",
         "Type": "Package",
         "Title": "A Wrapper of the JavaScript Library 'DataTables'",
-        "Version": "0.10",
+        "Version": "0.9",
         "Authors@R": "c(\n    person(\"Yihui\", \"Xie\", email = \"xie@yihui.name\", role = c(\"aut\", \"cre\")),\n    person(\"Joe\", \"Cheng\", role = \"aut\"),\n    person(\"Xianying\", \"Tan\", role = \"aut\"),\n    person(\"JJ\", \"Allaire\", role = \"ctb\"),\n    person(\"Maximilian\", \"Girlich\", role = \"ctb\"),\n    person(\"Greg\", \"Freedman Ellis\", role = \"ctb\"),\n    person(\"Johannes\", \"Rauh\", role = \"ctb\"),\n    person(\"jQuery contributors\", role = c(\"ctb\", \"cph\"), comment = \"jQuery in htmlwidgets/lib\"),\n    person(\"SpryMedia Limited\", role = c(\"ctb\", \"cph\"), comment = \"DataTables in htmlwidgets/lib\"),\n    person(\"Brian\", \"Reavis\", role = c(\"ctb\", \"cph\"), comment = \"selectize.js in htmlwidgets/lib\"),\n    person(\"Leon\", \"Gersen\", role = c(\"ctb\", \"cph\"), comment = \"noUiSlider in htmlwidgets/lib\"),\n    person(\"Bartek\", \"Szopka\", role = c(\"ctb\", \"cph\"), comment = \"jquery.highlight.js in htmlwidgets/lib\"),\n    person(\"RStudio Inc\", role = \"cph\")\n    )",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Description": "Data objects in R can be rendered as HTML tables using the\n    JavaScript library 'DataTables' (typically via R Markdown or Shiny). The\n    'DataTables' library has been included in this R package. The package name\n    'DT' is an abbreviation of 'DataTables'.",
-        "URL": "https://github.com/rstudio/DT",
+        "URL": "https://rstudio.github.io/DT",
         "BugReports": "https://github.com/rstudio/DT/issues",
         "License": "GPL-3 | file LICENSE",
         "Imports": "htmltools (>= 0.3.6), htmlwidgets (>= 1.3), jsonlite (>=\n0.9.16), magrittr, crosstalk, promises",
@@ -59,16 +60,16 @@
         "RoxygenNote": "6.1.1",
         "Encoding": "UTF-8",
         "NeedsCompilation": "no",
-        "Packaged": "2019-11-12 16:36:57 UTC; yihui",
+        "Packaged": "2019-09-17 04:12:43 UTC; yihui",
         "Author": "Yihui Xie [aut, cre],\n  Joe Cheng [aut],\n  Xianying Tan [aut],\n  JJ Allaire [ctb],\n  Maximilian Girlich [ctb],\n  Greg Freedman Ellis [ctb],\n  Johannes Rauh [ctb],\n  jQuery contributors [ctb, cph] (jQuery in htmlwidgets/lib),\n  SpryMedia Limited [ctb, cph] (DataTables in htmlwidgets/lib),\n  Brian Reavis [ctb, cph] (selectize.js in htmlwidgets/lib),\n  Leon Gersen [ctb, cph] (noUiSlider in htmlwidgets/lib),\n  Bartek Szopka [ctb, cph] (jquery.highlight.js in htmlwidgets/lib),\n  RStudio Inc [cph]",
         "Repository": "CRAN",
-        "Date/Publication": "2019-11-12 18:10:11 UTC",
-        "Built": "R 3.6.1; ; 2019-11-23 20:08:35 UTC; unix"
+        "Date/Publication": "2019-09-17 09:10:10 UTC",
+        "Built": "R 3.6.0; ; 2019-10-31 15:53:47 UTC; unix"
       }
     },
     "MASS": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -94,22 +95,23 @@
         "Packaged": "2019-03-31 07:00:08 UTC; ripley",
         "Author": "Brian Ripley [aut, cre, cph],\n  Bill Venables [ctb],\n  Douglas M. Bates [ctb],\n  Kurt Hornik [trl] (partial port ca 1998),\n  Albrecht Gebhardt [trl] (partial port ca 1998),\n  David Firth [ctb]",
         "Maintainer": "Brian Ripley <ripley@stats.ox.ac.uk>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-04-26 13:18:59 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 'Tue, 20 Aug 2019 01:51:29 +0000'; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:38:35 UTC; unix"
       }
     },
     "Matrix": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
       "GithubSha1": null,
       "description": {
         "Package": "Matrix",
-        "Version": "1.2-18",
-        "Date": "2019-11-25",
+        "Version": "1.2-17",
+        "Date": "2019-03-11",
         "Priority": "recommended",
         "Title": "Sparse and Dense Matrix Classes and Methods",
         "Contact": "Doug and Martin <Matrix-authors@R-project.org>",
@@ -128,16 +130,16 @@
         "URL": "http://Matrix.R-forge.R-project.org/",
         "BugReports": "https://r-forge.r-project.org/tracker/?group_id=61",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-11-26 17:17:19 UTC; maechler",
+        "Packaged": "2019-03-20 21:37:04 UTC; maechler",
         "Author": "Douglas Bates [aut],\n  Martin Maechler [aut, cre] (<https://orcid.org/0000-0002-8685-9910>),\n  Timothy A. Davis [ctb] (SuiteSparse and 'cs' C libraries, notably\n    CHOLMOD, AMD; collaborators listed in dir(pattern =\n    '^[A-Z]+[.]txt$', full.names=TRUE, system.file('doc',\n    'SuiteSparse', package='Matrix'))),\n  Jens Oehlschlägel [ctb] (initial nearPD()),\n  Jason Riedy [ctb] (condest() and onenormest() for octave, Copyright:\n    Regents of the University of California),\n  R Core Team [ctb] (base R matrix implementation)",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-27 15:20:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 'Sat, 07 Dec 2019 00:26:19 +0000'; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-03-22 22:56:52 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:33:27 UTC; unix"
       }
     },
     "R6": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -159,14 +161,15 @@
         "Packaged": "2019-11-12 20:00:15 UTC; winston",
         "Author": "Winston Chang [aut, cre]",
         "Maintainer": "Winston Chang <winston@stdout.org>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-11-12 22:50:03 UTC",
-        "Built": "R 3.6.1; ; 2019-11-23 19:51:09 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-11-13 16:30:36 UTC; unix"
       }
     },
     "RColorBrewer": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -184,14 +187,15 @@
         "License": "Apache License 2.0",
         "Packaged": "2014-12-06 23:59:42 UTC; neuwirth",
         "NeedsCompilation": "no",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2014-12-07 08:28:55",
-        "Built": "R 3.6.0; ; 2019-04-28 14:51:56 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-26 13:39:28 UTC; unix"
       }
     },
     "Rcpp": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -215,14 +219,15 @@
         "RoxygenNote": "6.1.1",
         "NeedsCompilation": "yes",
         "Packaged": "2019-11-08 18:25:32.94843 UTC; edd",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-11-08 23:44:12",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 19:51:11 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-11 20:46:44 UTC; unix"
       }
     },
     "askpass": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -247,14 +252,14 @@
         "Packaged": "2019-01-13 12:08:17 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>)",
         "Maintainer": "Jeroen Ooms <jeroen@berkeley.edu>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-01-13 12:50:03 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 15:01:04 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:36:46 UTC; unix"
       }
     },
     "assertthat": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -274,14 +279,46 @@
         "Packaged": "2019-03-21 13:11:01 UTC; hadley",
         "Author": "Hadley Wickham [aut, cre]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-03-21 14:53:46 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 14:55:21 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-26 13:32:57 UTC; unix"
+      }
+    },
+    "backports": {
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "backports",
+        "Type": "Package",
+        "Title": "Reimplementations of Functions Introduced Since R-3.0.0",
+        "Version": "1.1.5",
+        "Authors@R": "c(\n    person(\"Michel\", \"Lang\", NULL, \"michellang@gmail.com\",\n      role = c(\"cre\", \"aut\"), comment = c(ORCID = \"0000-0001-9754-0393\")),\n    person(\"R Core Team\", role = \"aut\"))",
+        "Maintainer": "Michel Lang <michellang@gmail.com>",
+        "Description": "\n    Functions introduced or changed since R v3.0.0 are re-implemented in this\n    package. The backports are conditionally exported in order to let R resolve\n    the function name to either the implemented backport, or the respective base\n    version, if available. Package developers can make use of new functions or\n    arguments by selectively importing specific backports to\n    support older installations.",
+        "URL": "https://github.com/r-lib/backports",
+        "BugReports": "https://github.com/r-lib/backports/issues",
+        "License": "GPL-2 | GPL-3",
+        "NeedsCompilation": "yes",
+        "ByteCompile": "yes",
+        "Depends": "R (>= 3.0.0)",
+        "Imports": "utils",
+        "Encoding": "UTF-8",
+        "RoxygenNote": "6.1.1",
+        "Packaged": "2019-10-02 18:35:28 UTC; michel",
+        "Author": "Michel Lang [cre, aut] (<https://orcid.org/0000-0001-9754-0393>),\n  R Core Team [aut]",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-10-02 20:20:02 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-10-03 10:56:55 UTC; unix"
       }
     },
     "base64enc": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -299,14 +336,47 @@
         "URL": "http://www.rforge.net/base64enc",
         "NeedsCompilation": "yes",
         "Packaged": "2015-02-04 20:31:00 UTC; svnuser",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2015-07-28 08:03:37",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-07-29 13:46:16 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:39:16 UTC; unix"
+      }
+    },
+    "callr": {
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "callr",
+        "Title": "Call R from R",
+        "Version": "3.3.2",
+        "Authors@R": "c(\n    person(\"Gábor\", \"Csárdi\", role = c(\"aut\", \"cre\", \"cph\"),\n           email = \"csardi.gabor@gmail.com\",\n\t   comment = c(ORCID = \"0000-0001-7098-9676\")),\n    person(\"Winston\", \"Chang\", role = \"aut\"),\n    person(\"RStudio\", role = c(\"cph\", \"fnd\")),\n    person(\"Mango Solutions\", role  = c(\"cph\", \"fnd\")))",
+        "Description": "It is sometimes useful to perform a computation in a\n    separate R process, without affecting the current R process at all.\n    This packages does exactly that.",
+        "License": "MIT + file LICENSE",
+        "LazyData": "true",
+        "URL": "https://github.com/r-lib/callr#readme",
+        "BugReports": "https://github.com/r-lib/callr/issues",
+        "RoxygenNote": "6.1.1",
+        "Imports": "processx (>= 3.4.0), R6, utils",
+        "Suggests": "cliapp, covr, crayon, fansi, knitr, pingr, ps, rmarkdown,\nrprojroot, spelling, testthat, tibble, withr",
+        "Encoding": "UTF-8",
+        "VignetteBuilder": "knitr",
+        "Language": "en-US",
+        "NeedsCompilation": "no",
+        "Packaged": "2019-09-22 09:12:55 UTC; gaborcsardi",
+        "Author": "Gábor Csárdi [aut, cre, cph] (<https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  RStudio [cph, fnd],\n  Mango Solutions [cph, fnd]",
+        "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-09-22 09:50:02 UTC",
+        "Built": "R 3.6.1; ; 2019-09-26 13:43:29 UTC; unix"
       }
     },
     "cli": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -330,14 +400,14 @@
         "Packaged": "2019-03-19 09:55:47 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Hadley Wickham [ctb],\n  Kirill Müller [ctb]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-03-19 10:43:26 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 15:01:13 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-26 13:43:51 UTC; unix"
       }
     },
     "colorspace": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -362,14 +432,15 @@
         "Packaged": "2019-03-18 09:11:41 UTC; zeileis",
         "Author": "Ross Ihaka [aut],\n  Paul Murrell [aut] (<https://orcid.org/0000-0002-3224-8858>),\n  Kurt Hornik [aut] (<https://orcid.org/0000-0003-4198-9911>),\n  Jason C. Fisher [aut] (<https://orcid.org/0000-0001-9032-8912>),\n  Reto Stauffer [aut] (<https://orcid.org/0000-0002-3798-5507>),\n  Claus O. Wilke [aut] (<https://orcid.org/0000-0002-7470-9261>),\n  Claire D. McWhite [aut] (<https://orcid.org/0000-0001-7346-3047>),\n  Achim Zeileis [aut, cre] (<https://orcid.org/0000-0003-0918-3766>)",
         "Maintainer": "Achim Zeileis <Achim.Zeileis@R-project.org>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-03-18 14:43:29 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 14:50:24 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:33:26 UTC; unix"
       }
     },
     "crayon": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -393,14 +464,14 @@
         "Packaged": "2017-09-15 18:14:04 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Brodie Gaslam [ctb]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2017-09-16 19:49:46 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 14:55:14 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-26 13:41:57 UTC; unix"
       }
     },
     "crosstalk": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -421,14 +492,15 @@
         "Packaged": "2016-12-20 20:01:51 UTC; jcheng",
         "Author": "Joe Cheng [aut, cre],\n  RStudio [cph],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Kristopher Michael Kowal [ctb, cph] (es5-shim library),\n  es5-shim contributors [ctb, cph] (es5-shim library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library)",
         "Maintainer": "Joe Cheng <joe@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2016-12-21 08:30:32",
-        "Built": "R 3.6.0; ; 2019-04-28 15:10:38 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-23 20:11:28 UTC; unix"
       }
     },
     "curl": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -437,32 +509,32 @@
         "Package": "curl",
         "Type": "Package",
         "Title": "A Modern and Flexible Web Client for R",
-        "Version": "4.3",
+        "Version": "3.3",
         "Authors@R": "c(\n    person(\"Jeroen\", \"Ooms\", role = c(\"aut\", \"cre\"), email = \"jeroen@berkeley.edu\",\n      comment = c(ORCID = \"0000-0002-4035-0289\")),\n    person(\"Hadley\", \"Wickham\", , \"hadley@rstudio.com\", role = \"ctb\"),\n    person(\"RStudio\", role = \"cph\")\n    )",
         "Description": "The curl() and curl_download() functions provide highly\n    configurable drop-in replacements for base url() and download.file() with\n    better performance, support for encryption (https, ftps), gzip compression,\n    authentication, and other 'libcurl' goodies. The core of the package implements a\n    framework for performing fully customized requests where data can be processed\n    either in memory, on disk, or streaming via the callback or connection\n    interfaces. Some knowledge of 'libcurl' is recommended; for a more-user-friendly\n    web client see the 'httr' package which builds on this package with http\n    specific tools and logic.",
         "License": "MIT + file LICENSE",
         "SystemRequirements": "libcurl: libcurl-devel (rpm) or\nlibcurl4-openssl-dev (deb).",
-        "URL": "https://jeroen.cran.dev/curl (docs)\nhttps://github.com/jeroen/curl#readme (devel)\nhttps://curl.haxx.se/libcurl/ (upstream)",
+        "URL": "https://github.com/jeroen/curl#readme (devel)\nhttps://curl.haxx.se/libcurl/ (upstream)",
         "BugReports": "https://github.com/jeroen/curl/issues",
         "Suggests": "spelling, testthat (>= 1.0.0), knitr, jsonlite, rmarkdown,\nmagrittr, httpuv (>= 1.4.4), webutils",
         "VignetteBuilder": "knitr",
         "Depends": "R (>= 3.0.0)",
         "LazyData": "true",
-        "RoxygenNote": "7.0.1",
+        "RoxygenNote": "6.1.1",
         "Encoding": "UTF-8",
         "Language": "en-US",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-12-02 12:33:03 UTC; jeroen",
+        "Packaged": "2019-01-09 22:29:50 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Hadley Wickham [ctb],\n  RStudio [cph]",
         "Maintainer": "Jeroen Ooms <jeroen@berkeley.edu>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-12-02 14:00:03 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-12-06 18:31:00 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-01-10 12:50:03 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-05 03:23:28 UTC; unix"
       }
     },
     "digest": {
       "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -486,12 +558,12 @@
         "Packaged": "2019-11-22 16:44:22.218585 UTC; edd",
         "Repository": "CRAN",
         "Date/Publication": "2019-11-23 09:40:07 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 19:50:28 UTC; unix"
+        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-12-13 20:08:34 UTC; unix"
       }
     },
     "dplyr": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -518,14 +590,14 @@
         "Packaged": "2019-07-04 05:04:15 UTC; romainfrancois",
         "Author": "Hadley Wickham [aut, cre] (<https://orcid.org/0000-0003-4757-117X>),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>),\n  Lionel Henry [aut],\n  Kirill Müller [aut] (<https://orcid.org/0000-0002-1416-3412>),\n  RStudio [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-07-04 15:50:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-12-05 14:56:48 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-05 17:06:48 UTC; unix"
       }
     },
     "ellipsis": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -551,12 +623,12 @@
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2019-09-20 20:40:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-24 20:01:16 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:34:44 UTC; unix"
       }
     },
     "evaluate": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -580,14 +652,14 @@
         "Packaged": "2019-05-28 15:30:02 UTC; yihui",
         "Author": "Hadley Wickham [aut],\n  Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Michael Lawrence [ctb],\n  Thomas Kluyver [ctb],\n  Jeroen Ooms [ctb],\n  Barret Schloerke [ctb],\n  Adam Ryczkowski [ctb],\n  Hiroaki Yutani [ctb],\n  Michel Lang [ctb],\n  Karolis Koncevičius [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-05-28 15:50:02 UTC",
-        "Built": "R 3.6.1; ; 2019-07-29 13:45:41 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-26 13:33:13 UTC; unix"
       }
     },
     "fansi": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -612,48 +684,18 @@
         "Packaged": "2018-10-04 19:06:14 UTC; bg",
         "Author": "Brodie Gaslam [aut, cre],\n  Elliott Sales De Andrade [ctb],\n  R Core Team [cph] (UTF8 byte length calcs from src/util.c)",
         "Maintainer": "Brodie Gaslam <brodie.gaslam@yahoo.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-10-05 05:10:12 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 14:54:04 UTC; unix"
-      }
-    },
-    "farver": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "GithubRepo": null,
-      "GithubUsername": null,
-      "GithubRef": null,
-      "GithubSha1": null,
-      "description": {
-        "Package": "farver",
-        "Type": "Package",
-        "Title": "High Performance Colour Space Manipulation",
-        "Version": "2.0.1",
-        "Authors@R": "\n    c(person(given = \"Thomas Lin\",\n             family = \"Pedersen\",\n             role = c(\"cre\", \"aut\"),\n             email = \"thomasp85@gmail.com\",\n             comment = c(ORCID = \"0000-0002-5147-4711\")),\n      person(given = \"Berendea\",\n             family = \"Nicolae\",\n             role = \"aut\",\n             comment = \"Author of the ColorSpace C++ library\"),\n      person(given = \"Romain\", \n             family = \"François\", \n             role = \"aut\", \n             email = \"romain@purrple.cat\",\n             comment = c(ORCID = \"0000-0002-2444-4226\")) \n      )",
-        "Maintainer": "Thomas Lin Pedersen <thomasp85@gmail.com>",
-        "Description": "The encoding of colour can be handled in many different ways, using\n    different colour spaces. As different colour spaces have different uses,\n    efficient conversion between these representations are important. The \n    'farver' package provides a set of functions that gives access to very fast\n    colour space conversion and comparisons implemented in C++, and offers \n    speed improvements over the 'convertColor' function in the 'grDevices' \n    package.",
-        "License": "MIT + file LICENSE",
-        "Encoding": "UTF-8",
-        "SystemRequirements": "C++11",
-        "RoxygenNote": "6.1.1",
-        "URL": "https://github.com/thomasp85/farver",
-        "BugReports": "https://github.com/thomasp85/farver/issues",
-        "Suggests": "testthat (>= 2.1.0), covr",
-        "NeedsCompilation": "yes",
-        "Packaged": "2019-11-13 19:27:13 UTC; thomas",
-        "Author": "Thomas Lin Pedersen [cre, aut]\n    (<https://orcid.org/0000-0002-5147-4711>),\n  Berendea Nicolae [aut] (Author of the ColorSpace C++ library),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>)",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-13 22:20:13 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 19:50:32 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:33:31 UTC; unix"
       }
     },
     "fastmap": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "GithubRepo": null,
-      "GithubUsername": null,
-      "GithubRef": null,
-      "GithubSha1": null,
+      "Source": "github",
+      "Repository": null,
+      "GithubRepo": "fastmap",
+      "GithubUsername": "r-lib",
+      "GithubRef": "master",
+      "GithubSha1": "6d0fafbdfe0b5c80762b0b9339e1ff8e4e006417",
       "description": {
         "Package": "fastmap",
         "Title": "Fast Implementation of a Key-Value Store",
@@ -667,18 +709,26 @@
         "Suggests": "testthat (>= 2.1.1)",
         "URL": "https://r-lib.github.io/fastmap/, https://github.com/r-lib/fastmap",
         "BugReports": "https://github.com/r-lib/fastmap/issues",
+        "RemoteType": "github",
+        "RemoteHost": "api.github.com",
+        "RemoteRepo": "fastmap",
+        "RemoteUsername": "r-lib",
+        "RemoteRef": "master",
+        "RemoteSha": "6d0fafbdfe0b5c80762b0b9339e1ff8e4e006417",
+        "GithubRepo": "fastmap",
+        "GithubUsername": "r-lib",
+        "GithubRef": "master",
+        "GithubSHA1": "6d0fafbdfe0b5c80762b0b9339e1ff8e4e006417",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-10-07 23:14:48 UTC; winston",
+        "Packaged": "2019-11-08 21:22:29 UTC; james",
         "Author": "Winston Chang [aut, cre],\n  RStudio [cph, fnd],\n  Tessil [cph] (hopscotch_map library)",
         "Maintainer": "Winston Chang <winston@rstudio.com>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-10-08 05:20:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 19:50:17 UTC; unix"
+        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-11-08 21:22:30 UTC; unix"
       }
     },
     "flexdashboard": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -702,21 +752,59 @@
         "Packaged": "2018-06-28 21:44:36 UTC; jcheng",
         "Author": "Richard Iannone [aut, cre] (<https://orcid.org/0000-0003-3925-190X>),\n  JJ Allaire [aut],\n  Barbara Borges [aut],\n  RStudio [cph],\n  Keen IO [ctb, cph] (Dashboard CSS),\n  Abdullah Almsaeed [ctb, cph] (Dashboard CSS),\n  Jonas Mosbech [ctb, cph] (StickyTableHeaders),\n  Noel Bossart [ctb, cph] (Featherlight),\n  Lea Verou [ctb, cph] (Prism),\n  Dmitry Baranovskiy [ctb, cph] (Raphael.js),\n  Sencha Labs [ctb, cph] (Raphael.js),\n  Bojan Djuricic [ctb, cph] (JustGage),\n  Tomas Sardyha [ctb, cph] (Sly),\n  Bryan Lewis [ctb, cph] (Examples),\n  Carson Sievert [ctb, cph] (Examples),\n  Joshua Kunst [ctb, cph] (Examples),\n  Ryan Hafen [ctb, cph] (Examples),\n  Bob Rudis [ctb, cph] (Examples),\n  Joe Cheng [ctb] (Examples)",
         "Maintainer": "Richard Iannone <rich@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-06-29 21:23:17 UTC",
-        "Built": "R 3.6.1; ; 2019-07-29 13:48:07 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-21 13:23:57 UTC; unix"
+      }
+    },
+    "fs": {
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "fs",
+        "Title": "Cross-Platform File System Operations Based on 'libuv'",
+        "Version": "1.3.1",
+        "Authors@R": "c(\n    person(\"Jim\", \"Hester\", email = \"james.f.hester@gmail.com\", role = c(\"aut\", \"cre\")),\n    person(\"Hadley\", \"Wickham\", , \"hadley@rstudio.com\", \"aut\"),\n    person(\"libuv project contributors\", role = \"cph\", comment = \"libuv library\"),\n    person(\"Joyent, Inc. and other Node contributors\", role = \"cph\", comment = \"libuv library\"),\n    person(\"RStudio\", role = c(\"cph\", \"fnd\"))\n    )",
+        "Description": "A cross-platform interface to file system operations, built on\n  top of the 'libuv' C library.",
+        "Depends": "R (>= 3.1)",
+        "License": "GPL-3",
+        "Encoding": "UTF-8",
+        "LazyData": "true",
+        "ByteCompile": "true",
+        "LinkingTo": "Rcpp",
+        "Imports": "methods, Rcpp",
+        "SystemRequirements": "GNU make",
+        "RoxygenNote": "6.1.1",
+        "URL": "http://fs.r-lib.org, https://github.com/r-lib/fs",
+        "BugReports": "https://github.com/r-lib/fs/issues",
+        "Copyright": "file COPYRIGHTS",
+        "Suggests": "testthat, covr, pillar (>= 1.0.0), crayon, rmarkdown, knitr,\nwithr, spelling",
+        "VignetteBuilder": "knitr",
+        "Language": "en-US",
+        "NeedsCompilation": "yes",
+        "Packaged": "2019-05-06 20:39:49 UTC; jhester",
+        "Author": "Jim Hester [aut, cre],\n  Hadley Wickham [aut],\n  libuv project contributors [cph] (libuv library),\n  Joyent, Inc. and other Node contributors [cph] (libuv library),\n  RStudio [cph, fnd]",
+        "Maintainer": "Jim Hester <james.f.hester@gmail.com>",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-05-06 22:50:03 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-11 21:45:11 UTC; unix"
       }
     },
     "ggplot2": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
       "GithubSha1": null,
       "description": {
         "Package": "ggplot2",
-        "Version": "3.2.1",
+        "Version": "3.2.0",
         "Title": "Create Elegant Data Visualisations Using the Grammar of Graphics",
         "Description": "A system for 'declaratively' creating graphics,\n    based on \"The Grammar of Graphics\". You provide the data, tell 'ggplot2'\n    how to map variables to aesthetics, what graphical primitives to use,\n    and it takes care of the details.",
         "Authors@R": "c(\n    person(\"Hadley\", \"Wickham\", , \"hadley@rstudio.com\", c(\"aut\", \"cre\")),\n    person(\"Winston\", \"Chang\", , role = \"aut\"),\n    person(\"Lionel\", \"Henry\", , role = \"aut\"),\n    person(\"Thomas Lin\", \"Pedersen\", role = \"aut\"),\n    person(\"Kohske\", \"Takahashi\", role = \"aut\"),\n    person(\"Claus\", \"Wilke\", role = \"aut\"),\n    person(\"Kara\", \"Woo\", role = \"aut\"),\n    person(\"Hiroaki\", \"Yutani\", role = \"aut\"),\n    person(\"RStudio\", role = c(\"cph\"))\n    )",
@@ -733,17 +821,17 @@
         "RoxygenNote": "6.1.1",
         "Encoding": "UTF-8",
         "NeedsCompilation": "no",
-        "Packaged": "2019-08-09 20:11:46 UTC; thomas",
+        "Packaged": "2019-06-13 19:32:10 UTC; thomas",
         "Author": "Hadley Wickham [aut, cre],\n  Winston Chang [aut],\n  Lionel Henry [aut],\n  Thomas Lin Pedersen [aut],\n  Kohske Takahashi [aut],\n  Claus Wilke [aut],\n  Kara Woo [aut],\n  Hiroaki Yutani [aut],\n  RStudio [cph]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
         "Repository": "RSPM",
-        "Date/Publication": "2019-08-10 22:30:13 UTC",
-        "Built": "R 3.6.1; ; 2019-09-10 14:57:47 UTC; unix"
+        "Date/Publication": "2019-06-16 14:00:03 UTC",
+        "Built": "R 3.6.1; ; 2019-08-01 20:51:47 UTC; unix"
       }
     },
     "glue": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -769,14 +857,14 @@
         "Packaged": "2019-03-11 21:03:11 UTC; jhester",
         "Author": "Jim Hester [aut, cre]",
         "Maintainer": "Jim Hester <james.f.hester@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-03-12 22:30:02 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 14:52:26 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:32:57 UTC; unix"
       }
     },
     "gridExtra": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -797,14 +885,15 @@
         "Packaged": "2017-09-08 22:52:09 UTC; baptiste",
         "Author": "Baptiste Auguie [aut, cre],\n  Anton Antonov [ctb]",
         "Maintainer": "Baptiste Auguie <baptiste.auguie@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2017-09-09 14:12:08 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 14:57:50 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-26 13:35:03 UTC; unix"
       }
     },
     "gtable": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -829,14 +918,14 @@
         "Packaged": "2019-03-25 14:56:43 UTC; thomas",
         "Author": "Hadley Wickham [aut, cre],\n  Thomas Lin Pedersen [aut],\n  RStudio [cph]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-03-25 19:50:02 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 14:53:12 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-26 13:34:15 UTC; unix"
       }
     },
     "highr": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -859,23 +948,24 @@
         "NeedsCompilation": "no",
         "Packaged": "2019-03-20 18:58:08 UTC; yihui",
         "Author": "Christopher Gandrud [ctb],\n  Qiang Li [ctb],\n  Yixuan Qiu [aut],\n  Yihui Xie [aut, cre]",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-03-20 21:10:33 UTC",
-        "Built": "R 3.6.1; ; 2019-07-29 13:45:45 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-26 13:32:56 UTC; unix"
       }
     },
     "htmltools": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "GithubRepo": null,
-      "GithubUsername": null,
-      "GithubRef": null,
-      "GithubSha1": null,
+      "Source": "github",
+      "Repository": null,
+      "GithubRepo": "htmltools",
+      "GithubUsername": "rstudio",
+      "GithubRef": "master",
+      "GithubSha1": "8ed21e2d5987cea625694a492f0f9136dc2466f8",
       "description": {
         "Package": "htmltools",
         "Type": "Package",
         "Title": "Tools for HTML",
-        "Version": "0.4.0",
+        "Version": "0.4.0.9000",
         "Author": "RStudio, Inc.",
         "Maintainer": "Joe Cheng <joe@rstudio.com>",
         "Description": "Tools for HTML generation and output.",
@@ -890,16 +980,24 @@
         "LinkingTo": "Rcpp",
         "Encoding": "UTF-8",
         "Collate": "'RcppExports.R' 'html_dependency.R' 'html_escape.R'\n'html_print.R' 'shim.R' 'utils.R' 'tags.R' 'template.R'",
+        "RemoteType": "github",
+        "RemoteHost": "api.github.com",
+        "RemoteRepo": "htmltools",
+        "RemoteUsername": "rstudio",
+        "RemoteRef": "master",
+        "RemoteSha": "8ed21e2d5987cea625694a492f0f9136dc2466f8",
+        "GithubRepo": "htmltools",
+        "GithubUsername": "rstudio",
+        "GithubRef": "master",
+        "GithubSHA1": "8ed21e2d5987cea625694a492f0f9136dc2466f8",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-10-04 17:43:48 UTC; jcheng",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-10-04 23:00:08 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 19:52:45 UTC; unix"
+        "Packaged": "2019-11-08 21:25:10 UTC; james",
+        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-11-08 21:25:11 UTC; unix"
       }
     },
     "htmlwidgets": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -908,7 +1006,7 @@
         "Package": "htmlwidgets",
         "Type": "Package",
         "Title": "HTML Widgets for R",
-        "Version": "1.5.1",
+        "Version": "1.3",
         "Authors@R": "c(\n    person(\"Ramnath\", \"Vaidyanathan\", role = c(\"aut\", \"cph\")),\n    person(\"Yihui\", \"Xie\", role = c(\"aut\")),\n    person(\"JJ\", \"Allaire\", role = c(\"aut\")),\n    person(\"Joe\", \"Cheng\", role = c(\"aut\", \"cre\"), email = \"joe@rstudio.com\"),\n    person(\"Kenton\", \"Russell\", role = c(\"aut\", \"cph\")),\n    person(family = \"RStudio\", role = \"cph\")\n    )",
         "Description": "A framework for creating HTML widgets that render in various\n    contexts including the R console, 'R Markdown' documents, and 'Shiny'\n    web applications.",
         "License": "MIT + file LICENSE",
@@ -918,19 +1016,20 @@
         "Enhances": "shiny (>= 1.1)",
         "URL": "https://github.com/ramnathv/htmlwidgets",
         "BugReports": "https://github.com/ramnathv/htmlwidgets/issues",
-        "RoxygenNote": "6.1.1",
+        "RoxygenNote": "6.0.1",
         "NeedsCompilation": "no",
-        "Packaged": "2019-10-07 21:55:31 UTC; jcheng",
+        "Packaged": "2018-09-20 17:18:43 UTC; jcheng",
         "Author": "Ramnath Vaidyanathan [aut, cph],\n  Yihui Xie [aut],\n  JJ Allaire [aut],\n  Joe Cheng [aut, cre],\n  Kenton Russell [aut, cph],\n  RStudio [cph]",
         "Maintainer": "Joe Cheng <joe@rstudio.com>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-10-08 08:40:02 UTC",
-        "Built": "R 3.6.1; ; 2019-11-23 20:01:15 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2018-09-30 15:10:13 UTC",
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-23 20:07:50 UTC; unix"
       }
     },
     "httpuv": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -958,12 +1057,12 @@
         "Packaged": "2019-09-11 04:12:10 UTC; jcheng",
         "Repository": "RSPM",
         "Date/Publication": "2019-09-11 05:40:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:28:21 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-10-07 13:57:53 UTC; unix"
       }
     },
     "httr": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -971,30 +1070,30 @@
       "description": {
         "Package": "httr",
         "Title": "Tools for Working with URLs and HTTP",
-        "Version": "1.4.1",
+        "Version": "1.4.0",
         "Authors@R": "\n    c(person(given = \"Hadley\",\n             family = \"Wickham\",\n             role = c(\"aut\", \"cre\"),\n             email = \"hadley@rstudio.com\"),\n      person(given = \"RStudio\",\n             role = \"cph\"))",
         "Description": "Useful tools for working with HTTP organised by\n    HTTP verbs (GET(), POST(), etc). Configuration functions make it easy\n    to control additional request components (authenticate(),\n    add_headers() and so on).",
         "License": "MIT + file LICENSE",
-        "URL": "https://httr.r-lib.org/, https://github.com/r-lib/httr",
+        "URL": "https://github.com/r-lib/httr",
         "BugReports": "https://github.com/r-lib/httr/issues",
-        "Depends": "R (>= 3.2)",
-        "Imports": "curl (>= 3.0.0), jsonlite, mime, openssl (>= 0.8), R6",
+        "Depends": "R (>= 3.1)",
+        "Imports": "curl (>= 0.9.1), jsonlite, mime, openssl (>= 0.8), R6",
         "Suggests": "covr, httpuv, jpeg, knitr, png, readr, rmarkdown, testthat\n(>= 0.8.0), xml2",
         "VignetteBuilder": "knitr",
         "Encoding": "UTF-8",
         "RoxygenNote": "6.1.1",
         "NeedsCompilation": "no",
-        "Packaged": "2019-07-30 13:44:18 UTC; hadley",
+        "Packaged": "2018-12-06 20:11:59 UTC; hadley",
         "Author": "Hadley Wickham [aut, cre],\n  RStudio [cph]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-08-05 14:30:02 UTC",
-        "Built": "R 3.6.1; ; 2019-09-06 13:17:56 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2018-12-11 08:40:06 UTC",
+        "Built": "R 3.6.1; ; 2019-08-01 20:48:44 UTC; unix"
       }
     },
     "jsonlite": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1015,14 +1114,15 @@
         "Suggests": "httr, curl, plyr, testthat, knitr, rmarkdown, R.rsp, sp",
         "RoxygenNote": "6.1.1",
         "Packaged": "2018-12-07 11:22:02 UTC; jeroen",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-12-07 12:50:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-07-29 13:46:13 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.2; x86_64-pc-linux-gnu; 2019-12-27 20:35:59 UTC; unix"
       }
     },
     "knitr": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1031,13 +1131,13 @@
         "Package": "knitr",
         "Type": "Package",
         "Title": "A General-Purpose Package for Dynamic Report Generation in R",
-        "Version": "1.26",
-        "Authors@R": "c(\n    person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\")),\n    person(\"Adam\", \"Vogt\", role = \"ctb\"),\n    person(\"Alastair\", \"Andrew\", role = \"ctb\"),\n    person(\"Alex\", \"Zvoleff\", role = \"ctb\"),\n    person(\"Andre\", \"Simon\", role = \"ctb\", comment = \"the CSS files under inst/themes/ were derived from the Highlight package http://www.andre-simon.de\"),\n    person(\"Aron\", \"Atkins\", role = \"ctb\"),\n    person(\"Aaron\", \"Wolen\", role = \"ctb\"),\n    person(\"Ashley\", \"Manton\", role = \"ctb\"),\n    person(\"Atsushi\", \"Yasumoto\", role = \"ctb\", comment = c(ORCID = \"0000-0002-8335-495X\")),\n    person(\"Ben\", \"Baumer\", role = \"ctb\"),\n    person(\"Brian\", \"Diggs\", role = \"ctb\"),\n    person(\"Brian\", \"Zhang\", role = \"ctb\"),\n    person(\"Cassio\", \"Pereira\", role = \"ctb\"),\n    person(\"Christophe\", \"Dervieux\", role = \"ctb\"),\n    person(\"David\", \"Hugh-Jones\", role = \"ctb\"),\n    person(\"David\", \"Robinson\", role = \"ctb\"),\n    person(\"Doug\", \"Hemken\", role = \"ctb\"),\n    person(\"Duncan\", \"Murdoch\", role = \"ctb\"),\n    person(\"Elio\", \"Campitelli\", role = \"ctb\"),\n    person(\"Emily\", \"Riederer\", role = \"ctb\"),\n    person(\"Fabian\", \"Hirschmann\", role = \"ctb\"),\n    person(\"Fitch\", \"Simeon\", role = \"ctb\"),\n    person(\"Forest\", \"Fang\", role = \"ctb\"),\n    person(c(\"Frank\", \"E\", \"Harrell\", \"Jr\"), role = \"ctb\", comment = \"the Sweavel package at inst/misc/Sweavel.sty\"),\n    person(\"Garrick\", \"Aden-Buie\", role = \"ctb\"),\n    person(\"Gregoire\", \"Detrez\", role = \"ctb\"),\n    person(\"Hadley\", \"Wickham\", role = \"ctb\"),\n    person(\"Hao\", \"Zhu\", role = \"ctb\"),\n    person(\"Heewon\", \"Jeon\", role = \"ctb\"),\n    person(\"Henrik\", \"Bengtsson\", role = \"ctb\"),\n    person(\"Hiroaki\", \"Yutani\", role = \"ctb\"),\n    person(\"Ian\", \"Lyttle\", role = \"ctb\"),\n    person(\"Hodges\", \"Daniel\", role = \"ctb\"),\n    person(\"Jake\", \"Burkhead\", role = \"ctb\"),\n    person(\"James\", \"Manton\", role = \"ctb\"),\n    person(\"Jared\", \"Lander\", role = \"ctb\"),\n    person(\"Jason\", \"Punyon\", role = \"ctb\"),\n    person(\"Javier\", \"Luraschi\", role = \"ctb\"),\n    person(\"Jeff\", \"Arnold\", role = \"ctb\"),\n    person(\"Jenny\", \"Bryan\", role = \"ctb\"),\n    person(\"Jeremy\", \"Ashkenas\", role = c(\"ctb\", \"cph\"), comment = \"the CSS file at inst/misc/docco-classic.css\"),\n    person(\"Jeremy\", \"Stephens\", role = \"ctb\"),\n    person(\"Jim\", \"Hester\", role = \"ctb\"),\n    person(\"Joe\", \"Cheng\", role = \"ctb\"),\n    person(\"Johannes\", \"Ranke\", role = \"ctb\"),\n    person(\"John\", \"Honaker\", role = \"ctb\"),\n    person(\"John\", \"Muschelli\", role = \"ctb\"),\n    person(\"Jonathan\", \"Keane\", role = \"ctb\"),\n    person(\"JJ\", \"Allaire\", role = \"ctb\"),\n    person(\"Johan\", \"Toloe\", role = \"ctb\"),\n    person(\"Jonathan\", \"Sidi\", role = \"ctb\"),\n    person(\"Joseph\", \"Larmarange\", role = \"ctb\"),\n    person(\"Julien\", \"Barnier\", role = \"ctb\"),\n    person(\"Kaiyin\", \"Zhong\", role = \"ctb\"),\n    person(\"Kamil\", \"Slowikowski\", role = \"ctb\"),\n    person(\"Karl\", \"Forner\", role = \"ctb\"),\n    person(c(\"Kevin\", \"K.\"), \"Smith\", role = \"ctb\"),\n    person(\"Kirill\", \"Mueller\", role = \"ctb\"),\n    person(\"Kohske\", \"Takahashi\", role = \"ctb\"),\n    person(\"Lorenz\", \"Walthert\", role = \"ctb\"),\n    person(\"Lucas\", \"Gallindo\", role = \"ctb\"),\n    person(\"Marius\", \"Hofert\", role = \"ctb\"),\n    person(\"Martin\", \"Modrák\", role = \"ctb\"),\n    person(\"Michael\", \"Chirico\", role = \"ctb\"),\n    person(\"Michael\", \"Friendly\", role = \"ctb\"),\n    person(\"Michal\", \"Bojanowski\", role = \"ctb\"),\n    person(\"Michel\", \"Kuhlmann\", role = \"ctb\"),\n    person(\"Miller\", \"Patrick\", role = \"ctb\"),\n    person(\"Nacho\", \"Caballero\", role = \"ctb\"),\n    person(\"Nick\", \"Salkowski\", role = \"ctb\"),\n    person(\"Niels Richard\", \"Hansen\", role = \"ctb\"),\n    person(\"Noam\", \"Ross\", role = \"ctb\"),\n    person(\"Obada\", \"Mahdi\", role = \"ctb\"),\n    person(\"Qiang\", \"Li\", role = \"ctb\"),\n    person(\"Ramnath\", \"Vaidyanathan\", role = \"ctb\"),\n    person(\"Richard\", \"Cotton\", role = \"ctb\"),\n    person(\"Robert\", \"Krzyzanowski\", role = \"ctb\"),\n    person(\"Romain\", \"Francois\", role = \"ctb\"),\n    person(\"Ruaridh\", \"Williamson\", role = \"ctb\"),\n    person(\"Scott\", \"Kostyshak\", role = \"ctb\"),\n    person(\"Sebastian\", \"Meyer\", role = \"ctb\"),\n    person(\"Sietse\", \"Brouwer\", role = \"ctb\"),\n    person(c(\"Simon\", \"de\"), \"Bernard\", role = \"ctb\"),\n    person(\"Sylvain\", \"Rousseau\", role = \"ctb\"),\n    person(\"Taiyun\", \"Wei\", role = \"ctb\"),\n    person(\"Thibaut\", \"Assus\", role = \"ctb\"),\n    person(\"Thibaut\", \"Lamadon\", role = \"ctb\"),\n    person(\"Thomas\", \"Leeper\", role = \"ctb\"),\n    person(\"Tim\", \"Mastny\", role = \"ctb\"),\n    person(\"Tom\", \"Torsney-Weir\", role = \"ctb\"),\n    person(\"Trevor\", \"Davis\", role = \"ctb\"),\n    person(\"Viktoras\", \"Veitas\", role = \"ctb\"),\n    person(\"Weicheng\", \"Zhu\", role = \"ctb\"),\n    person(\"Wush\", \"Wu\", role = \"ctb\"),\n    person(\"Zachary\", \"Foster\", role = \"ctb\")\n    )",
+        "Version": "1.23",
+        "Authors@R": "c(\n    person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\")),\n    person(\"Adam\", \"Vogt\", role = \"ctb\"),\n    person(\"Alastair\", \"Andrew\", role = \"ctb\"),\n    person(\"Alex\", \"Zvoleff\", role = \"ctb\"),\n    person(\"Andre\", \"Simon\", role = \"ctb\", comment = \"the CSS files under inst/themes/ were derived from the Highlight package http://www.andre-simon.de\"),\n    person(\"Aron\", \"Atkins\", role = \"ctb\"),\n    person(\"Aaron\", \"Wolen\", role = \"ctb\"),\n    person(\"Ashley\", \"Manton\", role = \"ctb\"),\n    person(\"Atsushi\", \"Yasumoto\", role = \"ctb\", comment = c(ORCID = \"0000-0002-8335-495X\")),\n    person(\"Ben\", \"Baumer\", role = \"ctb\"),\n    person(\"Brian\", \"Diggs\", role = \"ctb\"),\n    person(\"Brian\", \"Zhang\", role = \"ctb\"),\n    person(\"Cassio\", \"Pereira\", role = \"ctb\"),\n    person(\"Christophe\", \"Dervieux\", role = \"ctb\"),\n    person(\"David\", \"Hugh-Jones\", role = \"ctb\"),\n    person(\"David\", \"Robinson\", role = \"ctb\"),\n    person(\"Doug\", \"Hemken\", role = \"ctb\"),\n    person(\"Duncan\", \"Murdoch\", role = \"ctb\"),\n    person(\"Elio\", \"Campitelli\", role = \"ctb\"),\n    person(\"Emily\", \"Riederer\", role = \"ctb\"),\n    person(\"Fabian\", \"Hirschmann\", role = \"ctb\"),\n    person(\"Fitch\", \"Simeon\", role = \"ctb\"),\n    person(\"Forest\", \"Fang\", role = \"ctb\"),\n    person(c(\"Frank\", \"E\", \"Harrell\", \"Jr\"), role = \"ctb\", comment = \"the Sweavel package at inst/misc/Sweavel.sty\"),\n    person(\"Garrick\", \"Aden-Buie\", role = \"ctb\"),\n    person(\"Gregoire\", \"Detrez\", role = \"ctb\"),\n    person(\"Hadley\", \"Wickham\", role = \"ctb\"),\n    person(\"Hao\", \"Zhu\", role = \"ctb\"),\n    person(\"Heewon\", \"Jeon\", role = \"ctb\"),\n    person(\"Henrik\", \"Bengtsson\", role = \"ctb\"),\n    person(\"Hiroaki\", \"Yutani\", role = \"ctb\"),\n    person(\"Ian\", \"Lyttle\", role = \"ctb\"),\n    person(\"Hodges\", \"Daniel\", role = \"ctb\"),\n    person(\"Jake\", \"Burkhead\", role = \"ctb\"),\n    person(\"James\", \"Manton\", role = \"ctb\"),\n    person(\"Jared\", \"Lander\", role = \"ctb\"),\n    person(\"Jason\", \"Punyon\", role = \"ctb\"),\n    person(\"Javier\", \"Luraschi\", role = \"ctb\"),\n    person(\"Jeff\", \"Arnold\", role = \"ctb\"),\n    person(\"Jenny\", \"Bryan\", role = \"ctb\"),\n    person(\"Jeremy\", \"Ashkenas\", role = c(\"ctb\", \"cph\"), comment = \"the CSS file at inst/misc/docco-classic.css\"),\n    person(\"Jeremy\", \"Stephens\", role = \"ctb\"),\n    person(\"Jim\", \"Hester\", role = \"ctb\"),\n    person(\"Joe\", \"Cheng\", role = \"ctb\"),\n    person(\"Johannes\", \"Ranke\", role = \"ctb\"),\n    person(\"John\", \"Honaker\", role = \"ctb\"),\n    person(\"John\", \"Muschelli\", role = \"ctb\"),\n    person(\"Jonathan\", \"Keane\", role = \"ctb\"),\n    person(\"JJ\", \"Allaire\", role = \"ctb\"),\n    person(\"Johan\", \"Toloe\", role = \"ctb\"),\n    person(\"Jonathan\", \"Sidi\", role = \"ctb\"),\n    person(\"Joseph\", \"Larmarange\", role = \"ctb\"),\n    person(\"Julien\", \"Barnier\", role = \"ctb\"),\n    person(\"Kaiyin\", \"Zhong\", role = \"ctb\"),\n    person(\"Kamil\", \"Slowikowski\", role = \"ctb\"),\n    person(\"Karl\", \"Forner\", role = \"ctb\"),\n    person(c(\"Kevin\", \"K.\"), \"Smith\", role = \"ctb\"),\n    person(\"Kirill\", \"Mueller\", role = \"ctb\"),\n    person(\"Kohske\", \"Takahashi\", role = \"ctb\"),\n    person(\"Lorenz\", \"Walthert\", role = \"ctb\"),\n    person(\"Lucas\", \"Gallindo\", role = \"ctb\"),\n    person(\"Marius\", \"Hofert\", role = \"ctb\"),\n    person(\"Martin\", \"Modrák\", role = \"ctb\"),\n    person(\"Michael\", \"Chirico\", role = \"ctb\"),\n    person(\"Michael\", \"Friendly\", role = \"ctb\"),\n    person(\"Michal\", \"Bojanowski\", role = \"ctb\"),\n    person(\"Michel\", \"Kuhlmann\", role = \"ctb\"),\n    person(\"Miller\", \"Patrick\", role = \"ctb\"),\n    person(\"Nacho\", \"Caballero\", role = \"ctb\"),\n    person(\"Nick\", \"Salkowski\", role = \"ctb\"),\n    person(\"Noam\", \"Ross\", role = \"ctb\"),\n    person(\"Obada\", \"Mahdi\", role = \"ctb\"),\n    person(\"Qiang\", \"Li\", role = \"ctb\"),\n    person(\"Ramnath\", \"Vaidyanathan\", role = \"ctb\"),\n    person(\"Richard\", \"Cotton\", role = \"ctb\"),\n    person(\"Robert\", \"Krzyzanowski\", role = \"ctb\"),\n    person(\"Romain\", \"Francois\", role = \"ctb\"),\n    person(\"Ruaridh\", \"Williamson\", role = \"ctb\"),\n    person(\"Scott\", \"Kostyshak\", role = \"ctb\"),\n    person(\"Sebastian\", \"Meyer\", role = \"ctb\"),\n    person(\"Sietse\", \"Brouwer\", role = \"ctb\"),\n    person(c(\"Simon\", \"de\"), \"Bernard\", role = \"ctb\"),\n    person(\"Sylvain\", \"Rousseau\", role = \"ctb\"),\n    person(\"Taiyun\", \"Wei\", role = \"ctb\"),\n    person(\"Thibaut\", \"Assus\", role = \"ctb\"),\n    person(\"Thibaut\", \"Lamadon\", role = \"ctb\"),\n    person(\"Thomas\", \"Leeper\", role = \"ctb\"),\n    person(\"Tim\", \"Mastny\", role = \"ctb\"),\n    person(\"Tom\", \"Torsney-Weir\", role = \"ctb\"),\n    person(\"Trevor\", \"Davis\", role = \"ctb\"),\n    person(\"Viktoras\", \"Veitas\", role = \"ctb\"),\n    person(\"Weicheng\", \"Zhu\", role = \"ctb\"),\n    person(\"Wush\", \"Wu\", role = \"ctb\"),\n    person(\"Zachary\", \"Foster\", role = \"ctb\")\n    )",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Description": "Provides a general-purpose tool for dynamic report generation in R\n    using Literate Programming techniques.",
         "Depends": "R (>= 3.2.3)",
         "Imports": "evaluate (>= 0.10), highr, markdown, stringr (>= 0.6), yaml\n(>= 2.1.19), methods, xfun, tools",
-        "Suggests": "formatR, testit, digest, rgl (>= 0.95.1201), codetools,\nrmarkdown, htmlwidgets (>= 0.7), webshot, tikzDevice (>= 0.10),\ntinytex, reticulate (>= 1.4), JuliaCall (>= 0.11.1), magick,\npng, jpeg, gifski, xml2 (>= 1.2.0), httr, DBI (>= 0.4-1),\nshowtext, tibble, sass, styler (>= 1.2.0)",
+        "Suggests": "formatR, testit, digest, rgl (>= 0.95.1201), codetools,\nrmarkdown, htmlwidgets (>= 0.7), webshot, tikzDevice (>= 0.10),\ntinytex, reticulate (>= 1.4), JuliaCall (>= 0.11.1), magick,\npng, jpeg, gifski, xml2 (>= 1.2.0), httr, DBI (>= 0.4-1),\nshowtext, tibble, styler",
         "License": "GPL",
         "URL": "https://yihui.name/knitr/",
         "BugReports": "https://github.com/yihui/knitr/issues",
@@ -1047,16 +1147,16 @@
         "Collate": "'block.R' 'cache.R' 'utils.R' 'citation.R' 'hooks-html.R'\n'plot.R' 'defaults.R' 'concordance.R' 'engine.R' 'highlight.R'\n'themes.R' 'header.R' 'hooks-asciidoc.R' 'hooks-chunk.R'\n'hooks-extra.R' 'hooks-latex.R' 'hooks-md.R' 'hooks-rst.R'\n'hooks-textile.R' 'hooks.R' 'output.R' 'package.R' 'pandoc.R'\n'params.R' 'parser.R' 'pattern.R' 'rocco.R' 'spin.R' 'table.R'\n'template.R' 'utils-base64.R' 'utils-conversion.R'\n'utils-rd2html.R' 'utils-sweave.R' 'utils-upload.R'\n'utils-vignettes.R' 'zzz.R'",
         "RoxygenNote": "6.1.1",
         "NeedsCompilation": "no",
-        "Packaged": "2019-11-12 20:05:16 UTC; yihui",
-        "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Adam Vogt [ctb],\n  Alastair Andrew [ctb],\n  Alex Zvoleff [ctb],\n  Andre Simon [ctb] (the CSS files under inst/themes/ were derived from\n    the Highlight package http://www.andre-simon.de),\n  Aron Atkins [ctb],\n  Aaron Wolen [ctb],\n  Ashley Manton [ctb],\n  Atsushi Yasumoto [ctb] (<https://orcid.org/0000-0002-8335-495X>),\n  Ben Baumer [ctb],\n  Brian Diggs [ctb],\n  Brian Zhang [ctb],\n  Cassio Pereira [ctb],\n  Christophe Dervieux [ctb],\n  David Hugh-Jones [ctb],\n  David Robinson [ctb],\n  Doug Hemken [ctb],\n  Duncan Murdoch [ctb],\n  Elio Campitelli [ctb],\n  Emily Riederer [ctb],\n  Fabian Hirschmann [ctb],\n  Fitch Simeon [ctb],\n  Forest Fang [ctb],\n  Frank E Harrell Jr [ctb] (the Sweavel package at inst/misc/Sweavel.sty),\n  Garrick Aden-Buie [ctb],\n  Gregoire Detrez [ctb],\n  Hadley Wickham [ctb],\n  Hao Zhu [ctb],\n  Heewon Jeon [ctb],\n  Henrik Bengtsson [ctb],\n  Hiroaki Yutani [ctb],\n  Ian Lyttle [ctb],\n  Hodges Daniel [ctb],\n  Jake Burkhead [ctb],\n  James Manton [ctb],\n  Jared Lander [ctb],\n  Jason Punyon [ctb],\n  Javier Luraschi [ctb],\n  Jeff Arnold [ctb],\n  Jenny Bryan [ctb],\n  Jeremy Ashkenas [ctb, cph] (the CSS file at\n    inst/misc/docco-classic.css),\n  Jeremy Stephens [ctb],\n  Jim Hester [ctb],\n  Joe Cheng [ctb],\n  Johannes Ranke [ctb],\n  John Honaker [ctb],\n  John Muschelli [ctb],\n  Jonathan Keane [ctb],\n  JJ Allaire [ctb],\n  Johan Toloe [ctb],\n  Jonathan Sidi [ctb],\n  Joseph Larmarange [ctb],\n  Julien Barnier [ctb],\n  Kaiyin Zhong [ctb],\n  Kamil Slowikowski [ctb],\n  Karl Forner [ctb],\n  Kevin K. Smith [ctb],\n  Kirill Mueller [ctb],\n  Kohske Takahashi [ctb],\n  Lorenz Walthert [ctb],\n  Lucas Gallindo [ctb],\n  Marius Hofert [ctb],\n  Martin Modrák [ctb],\n  Michael Chirico [ctb],\n  Michael Friendly [ctb],\n  Michal Bojanowski [ctb],\n  Michel Kuhlmann [ctb],\n  Miller Patrick [ctb],\n  Nacho Caballero [ctb],\n  Nick Salkowski [ctb],\n  Niels Richard Hansen [ctb],\n  Noam Ross [ctb],\n  Obada Mahdi [ctb],\n  Qiang Li [ctb],\n  Ramnath Vaidyanathan [ctb],\n  Richard Cotton [ctb],\n  Robert Krzyzanowski [ctb],\n  Romain Francois [ctb],\n  Ruaridh Williamson [ctb],\n  Scott Kostyshak [ctb],\n  Sebastian Meyer [ctb],\n  Sietse Brouwer [ctb],\n  Simon de Bernard [ctb],\n  Sylvain Rousseau [ctb],\n  Taiyun Wei [ctb],\n  Thibaut Assus [ctb],\n  Thibaut Lamadon [ctb],\n  Thomas Leeper [ctb],\n  Tim Mastny [ctb],\n  Tom Torsney-Weir [ctb],\n  Trevor Davis [ctb],\n  Viktoras Veitas [ctb],\n  Weicheng Zhu [ctb],\n  Wush Wu [ctb],\n  Zachary Foster [ctb]",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-12 21:00:02 UTC",
-        "Built": "R 3.6.1; ; 2019-11-23 19:53:03 UTC; unix"
+        "Packaged": "2019-05-18 03:49:56 UTC; yihui",
+        "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Adam Vogt [ctb],\n  Alastair Andrew [ctb],\n  Alex Zvoleff [ctb],\n  Andre Simon [ctb] (the CSS files under inst/themes/ were derived from\n    the Highlight package http://www.andre-simon.de),\n  Aron Atkins [ctb],\n  Aaron Wolen [ctb],\n  Ashley Manton [ctb],\n  Atsushi Yasumoto [ctb] (<https://orcid.org/0000-0002-8335-495X>),\n  Ben Baumer [ctb],\n  Brian Diggs [ctb],\n  Brian Zhang [ctb],\n  Cassio Pereira [ctb],\n  Christophe Dervieux [ctb],\n  David Hugh-Jones [ctb],\n  David Robinson [ctb],\n  Doug Hemken [ctb],\n  Duncan Murdoch [ctb],\n  Elio Campitelli [ctb],\n  Emily Riederer [ctb],\n  Fabian Hirschmann [ctb],\n  Fitch Simeon [ctb],\n  Forest Fang [ctb],\n  Frank E Harrell Jr [ctb] (the Sweavel package at inst/misc/Sweavel.sty),\n  Garrick Aden-Buie [ctb],\n  Gregoire Detrez [ctb],\n  Hadley Wickham [ctb],\n  Hao Zhu [ctb],\n  Heewon Jeon [ctb],\n  Henrik Bengtsson [ctb],\n  Hiroaki Yutani [ctb],\n  Ian Lyttle [ctb],\n  Hodges Daniel [ctb],\n  Jake Burkhead [ctb],\n  James Manton [ctb],\n  Jared Lander [ctb],\n  Jason Punyon [ctb],\n  Javier Luraschi [ctb],\n  Jeff Arnold [ctb],\n  Jenny Bryan [ctb],\n  Jeremy Ashkenas [ctb, cph] (the CSS file at\n    inst/misc/docco-classic.css),\n  Jeremy Stephens [ctb],\n  Jim Hester [ctb],\n  Joe Cheng [ctb],\n  Johannes Ranke [ctb],\n  John Honaker [ctb],\n  John Muschelli [ctb],\n  Jonathan Keane [ctb],\n  JJ Allaire [ctb],\n  Johan Toloe [ctb],\n  Jonathan Sidi [ctb],\n  Joseph Larmarange [ctb],\n  Julien Barnier [ctb],\n  Kaiyin Zhong [ctb],\n  Kamil Slowikowski [ctb],\n  Karl Forner [ctb],\n  Kevin K. Smith [ctb],\n  Kirill Mueller [ctb],\n  Kohske Takahashi [ctb],\n  Lorenz Walthert [ctb],\n  Lucas Gallindo [ctb],\n  Marius Hofert [ctb],\n  Martin Modrák [ctb],\n  Michael Chirico [ctb],\n  Michael Friendly [ctb],\n  Michal Bojanowski [ctb],\n  Michel Kuhlmann [ctb],\n  Miller Patrick [ctb],\n  Nacho Caballero [ctb],\n  Nick Salkowski [ctb],\n  Noam Ross [ctb],\n  Obada Mahdi [ctb],\n  Qiang Li [ctb],\n  Ramnath Vaidyanathan [ctb],\n  Richard Cotton [ctb],\n  Robert Krzyzanowski [ctb],\n  Romain Francois [ctb],\n  Ruaridh Williamson [ctb],\n  Scott Kostyshak [ctb],\n  Sebastian Meyer [ctb],\n  Sietse Brouwer [ctb],\n  Simon de Bernard [ctb],\n  Sylvain Rousseau [ctb],\n  Taiyun Wei [ctb],\n  Thibaut Assus [ctb],\n  Thibaut Lamadon [ctb],\n  Thomas Leeper [ctb],\n  Tim Mastny [ctb],\n  Tom Torsney-Weir [ctb],\n  Trevor Davis [ctb],\n  Viktoras Veitas [ctb],\n  Weicheng Zhu [ctb],\n  Wush Wu [ctb],\n  Zachary Foster [ctb]",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-05-18 05:10:02 UTC",
+        "Built": "R 3.6.1; ; 2019-08-01 20:50:37 UTC; unix"
       }
     },
     "labeling": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1073,19 +1173,20 @@
         "License": "MIT + file LICENSE | Unlimited",
         "LazyLoad": "no",
         "Collate": "'labeling.R'",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Repository/R-Forge/Project": "labeling",
         "Repository/R-Forge/Revision": "16",
         "Repository/R-Forge/DateTimeStamp": "2014-08-23 05:53:23",
         "Date/Publication": "2014-08-23 14:57:53",
         "Packaged": "2014-08-23 06:15:07 UTC; rforge",
         "NeedsCompilation": "no",
-        "Built": "R 3.6.0; ; 2019-04-28 14:51:54 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-26 13:35:50 UTC; unix"
       }
     },
     "later": {
       "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1111,12 +1212,12 @@
         "Maintainer": "Joe Cheng <joe@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2019-10-04 05:00:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 19:53:08 UTC; unix"
+        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-11-08 21:28:15 UTC; unix"
       }
     },
     "lattice": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1141,14 +1242,15 @@
         "BugReports": "https://github.com/deepayan/lattice/issues",
         "NeedsCompilation": "yes",
         "Packaged": "2018-11-04 11:39:05 UTC; deepayan",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-11-04 12:50:03 UTC",
-        "Built": "R 3.5.1; x86_64-pc-linux-gnu; \"Sat, 10 Nov 2018 14:56:01 +0000\"; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:32:58 UTC; unix"
       }
     },
     "lazyeval": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1169,14 +1271,15 @@
         "Packaged": "2019-03-15 14:18:01 UTC; lionel",
         "Author": "Hadley Wickham [aut, cre],\n  RStudio [cph]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-03-15 17:50:07 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 14:53:13 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:33:02 UTC; unix"
       }
     },
     "leaflet": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1185,95 +1288,30 @@
         "Package": "leaflet",
         "Type": "Package",
         "Title": "Create Interactive Web Maps with the JavaScript 'Leaflet'\nLibrary",
-        "Version": "2.0.3",
-        "Authors@R": "c(\n      person(\"Joe\", \"Cheng\", email = \"joe@rstudio.com\", role = c(\"aut\", \"cre\")),\n      person(\"Bhaskar\", \"Karambelkar\", role = c(\"aut\")),\n      person(\"Yihui\", \"Xie\", role = c(\"aut\")),\n      person(\"Hadley\", \"Wickham\", role = c(\"ctb\")),\n      person(\"Kenton\", \"Russell\", role = c(\"ctb\")),\n      person(\"Kent\", \"Johnson\", role = c(\"ctb\")),\n      person(\"Barret\", \"Schloerke\", role = c(\"ctb\")),\n      person(\"jQuery Foundation and contributors\", role = c(\"ctb\", \"cph\"), comment = \"jQuery library\"),\n      person(\"Vladimir\", \"Agafonkin\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet library\"),\n      person(\"CloudMade\", role = c(\"cph\"), comment = \"Leaflet library\"),\n      person(\"Leaflet contributors\", role = c(\"ctb\"), comment = \"Leaflet library\"),\n      person(\"Brandon Copeland\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-measure plugin\"),\n      person(\"Joerg Dietrich\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.Terminator plugin\"),\n      person(\"Benjamin Becquet\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.MagnifyingGlass plugin\"),\n      person(\"Norkart AS\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.MiniMap plugin\"),\n      person(\"L. Voogdt\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.awesome-markers plugin\"),\n      person(\"Daniel Montague\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.EasyButton plugin\"),\n      person(\"Kartena AB\", role = c(\"ctb\", \"cph\"), comment = \"Proj4Leaflet plugin\"),\n      person(\"Robert Kajic\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-locationfilter plugin\"),\n      person(\"Mapbox\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-omnivore plugin\"),\n      person(\"Michael Bostock\", role = c(\"ctb\", \"cph\"), comment = \"topojson\"),\n      person(\"RStudio\", role = c(\"cph\"))\n    )",
+        "Version": "2.0.2",
+        "Authors@R": "c(\n      person(\"Joe\", \"Cheng\", email = \"joe@rstudio.com\", role = c(\"aut\", \"cre\")),\n      person(\"Bhaskar\", \"Karambelkar\", role = c(\"aut\")),\n      person(\"Yihui\", \"Xie\", role = c(\"aut\")),\n      person(\"Hadley\", \"Wickham\", role = c(\"ctb\")),\n      person(\"Kenton\", \"Russell\", role = c(\"ctb\")),\n      person(\"Kent\", \"Johnson\", role = c(\"ctb\")),\n      person(\"Barret\", \"Schloerke\", role = c(\"ctb\")),\n      person(\"jQuery Foundation and contributors\", role = c(\"ctb\", \"cph\"), comment = \"jQuery library\"),\n      person(\"Vladimir\", \"Agafonkin\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet library\"),\n      person(\"CloudMade\", role = c(\"cph\"), comment = \"Leaflet library\"),\n      person(\"Leaflet contributors\", role = c(\"ctb\"), comment = \"Leaflet library\"),\n      person(\"Leaflet Providers contributors\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet Providers plugin\"),\n      person(\"Brandon Copeland\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-measure plugin\"),\n      person(\"Joerg Dietrich\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.Terminator plugin\"),\n      person(\"Benjamin Becquet\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.MagnifyingGlass plugin\"),\n      person(\"Norkart AS\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.MiniMap plugin\"),\n      person(\"L. Voogdt\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.awesome-markers plugin\"),\n      person(\"Daniel Montague\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet.EasyButton plugin\"),\n      person(\"Kartena AB\", role = c(\"ctb\", \"cph\"), comment = \"Proj4Leaflet plugin\"),\n      person(\"Robert Kajic\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-locationfilter plugin\"),\n      person(\"Mapbox\", role = c(\"ctb\", \"cph\"), comment = \"leaflet-omnivore plugin\"),\n      person(\"Michael Bostock\", role = c(\"ctb\", \"cph\"), comment = \"topojson\"),\n      person(\"RStudio\", role = c(\"cph\"))\n    )",
+        "Maintainer": "Joe Cheng <joe@rstudio.com>",
         "Description": "Create and customize interactive maps using the 'Leaflet'\n    JavaScript library and the 'htmlwidgets' package. These maps can be used\n    directly from the R console, from 'RStudio', in Shiny applications and R Markdown\n    documents.",
         "License": "GPL-3",
         "URL": "http://rstudio.github.io/leaflet/",
         "BugReports": "https://github.com/rstudio/leaflet/issues",
         "Depends": "R (>= 3.1.0)",
-        "Imports": "base64enc, crosstalk, htmlwidgets, htmltools, magrittr,\nmarkdown, methods, png, RColorBrewer, raster, scales (>=\n1.0.0), sp, stats, viridis (>= 0.5.1), leaflet.providers (>=\n1.8.0)",
-        "Suggests": "knitr, maps, sf, shiny, rgdal, rgeos, R6, RJSONIO, purrr,\ntestthat",
-        "RoxygenNote": "6.1.1",
+        "Imports": "base64enc, crosstalk, htmlwidgets, htmltools, magrittr,\nmarkdown, methods, png, RColorBrewer, raster, scales (>=\n1.0.0), sp, stats, viridis (>= 0.5.1)",
+        "Suggests": "knitr, maps, sf, shiny, testit (>= 0.4), rgdal, rgeos, R6,\nRJSONIO, purrr, testthat",
+        "RoxygenNote": "6.1.0",
         "Encoding": "UTF-8",
         "LazyData": "true",
         "NeedsCompilation": "no",
-        "Packaged": "2019-11-14 18:00:03 UTC; barret",
-        "Author": "Joe Cheng [aut, cre],\n  Bhaskar Karambelkar [aut],\n  Yihui Xie [aut],\n  Hadley Wickham [ctb],\n  Kenton Russell [ctb],\n  Kent Johnson [ctb],\n  Barret Schloerke [ctb],\n  jQuery Foundation and contributors [ctb, cph] (jQuery library),\n  Vladimir Agafonkin [ctb, cph] (Leaflet library),\n  CloudMade [cph] (Leaflet library),\n  Leaflet contributors [ctb] (Leaflet library),\n  Brandon Copeland [ctb, cph] (leaflet-measure plugin),\n  Joerg Dietrich [ctb, cph] (Leaflet.Terminator plugin),\n  Benjamin Becquet [ctb, cph] (Leaflet.MagnifyingGlass plugin),\n  Norkart AS [ctb, cph] (Leaflet.MiniMap plugin),\n  L. Voogdt [ctb, cph] (Leaflet.awesome-markers plugin),\n  Daniel Montague [ctb, cph] (Leaflet.EasyButton plugin),\n  Kartena AB [ctb, cph] (Proj4Leaflet plugin),\n  Robert Kajic [ctb, cph] (leaflet-locationfilter plugin),\n  Mapbox [ctb, cph] (leaflet-omnivore plugin),\n  Michael Bostock [ctb, cph] (topojson),\n  RStudio [cph]",
-        "Maintainer": "Joe Cheng <joe@rstudio.com>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-16 05:50:05 UTC",
-        "Built": "R 3.6.1; ; 2019-11-23 20:08:37 UTC; unix"
-      }
-    },
-    "leaflet.providers": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "GithubRepo": null,
-      "GithubUsername": null,
-      "GithubRef": null,
-      "GithubSha1": null,
-      "description": {
-        "Package": "leaflet.providers",
-        "Type": "Package",
-        "Title": "Leaflet Providers",
-        "Version": "1.9.0",
-        "Authors@R": "c(\n      person(\"Leslie\", \"Huang\", email = \"lesliehuang@nyu.edu\", role = c(\"aut\")),\n      person(\"Barret\", \"Schloerke\", email = \"barret@rstudio.com\", role = c(\"ctb\", \"cre\"),\n        comment = c(ORCID = \"0000-0001-9986-114X\")),\n      person(\"Leaflet Providers contributors\", role = c(\"ctb\", \"cph\"), comment = \"Leaflet Providers plugin\"),\n      person(\"RStudio\", role = c(\"cph\", \"fnd\"))\n    )",
-        "Description": "Contains third-party map tile provider information from\n    'Leaflet.js', <https://github.com/leaflet-extras/leaflet-providers>, to be\n    used with the 'leaflet' R package. Additionally, 'leaflet.providers'\n    enables users to retrieve up-to-date provider information between package\n    updates.",
-        "License": "BSD_2_clause + file LICENSE",
-        "Encoding": "UTF-8",
-        "LazyData": "true",
-        "Depends": "R (>= 2.10)",
-        "Suggests": "V8, jsonlite, testthat (>= 2.1.0)",
-        "Language": "en-US",
-        "RoxygenNote": "6.1.1",
-        "URL": "https://github.com/rstudio/leaflet.providers",
-        "BugReports": "https://github.com/rstudio/leaflet.providers/issues",
-        "Collate": "'providers_data.R' 'get_current_providers.R'",
-        "NeedsCompilation": "no",
-        "Packaged": "2019-11-08 22:12:22 UTC; barret",
-        "Author": "Leslie Huang [aut],\n  Barret Schloerke [ctb, cre] (<https://orcid.org/0000-0001-9986-114X>),\n  Leaflet Providers contributors [ctb, cph] (Leaflet Providers plugin),\n  RStudio [cph, fnd]",
-        "Maintainer": "Barret Schloerke <barret@rstudio.com>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-09 23:40:09 UTC",
-        "Built": "R 3.6.1; ; 2019-11-23 19:50:16 UTC; unix"
-      }
-    },
-    "lifecycle": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "GithubRepo": null,
-      "GithubUsername": null,
-      "GithubRef": null,
-      "GithubSha1": null,
-      "description": {
-        "Package": "lifecycle",
-        "Title": "Manage the Life Cycle of your Package Functions",
-        "Version": "0.1.0",
-        "Authors@R": "\n    c(\n      person(given = \"Lionel\", family = \"Henry\", role = c(\"aut\", \"cre\"), email = \"lionel@rstudio.com\"),\n      person(given = \"RStudio\", role = \"cph\")\n    )",
-        "Description": "Manage the life cycle of your exported functions with\n    shared conventions, documentation badges, and non-invasive\n    deprecation warnings. The 'lifecycle' package defines four\n    development stages (experimental, maturing, stable, and\n    questioning) and three deprecation stages (soft-deprecated,\n    deprecated, and defunct). It makes it easy to insert badges\n    corresponding to these stages in your documentation. Usage of\n    deprecated functions are signalled with increasing levels of\n    non-invasive verbosity.",
-        "License": "GPL-3",
-        "Encoding": "UTF-8",
-        "LazyData": "true",
-        "Depends": "R (>= 3.2)",
-        "Imports": "glue, rlang (>= 0.4.0)",
-        "Suggests": "covr, crayon, knitr, rmarkdown, testthat (>= 2.1.0)",
-        "RoxygenNote": "6.1.1",
-        "URL": "https://github.com/r-lib/lifecycle",
-        "BugReports": "https://github.com/r-lib/lifecycle/issues",
-        "VignetteBuilder": "knitr",
-        "NeedsCompilation": "no",
-        "Packaged": "2019-07-27 07:28:35 UTC; lionel",
-        "Author": "Lionel Henry [aut, cre],\n  RStudio [cph]",
-        "Maintainer": "Lionel Henry <lionel@rstudio.com>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-08-01 12:50:05 UTC",
-        "Built": "R 3.6.1; ; 2019-09-03 14:24:29 UTC; unix"
+        "Packaged": "2018-08-24 20:03:55 UTC; barret",
+        "Author": "Joe Cheng [aut, cre],\n  Bhaskar Karambelkar [aut],\n  Yihui Xie [aut],\n  Hadley Wickham [ctb],\n  Kenton Russell [ctb],\n  Kent Johnson [ctb],\n  Barret Schloerke [ctb],\n  jQuery Foundation and contributors [ctb, cph] (jQuery library),\n  Vladimir Agafonkin [ctb, cph] (Leaflet library),\n  CloudMade [cph] (Leaflet library),\n  Leaflet contributors [ctb] (Leaflet library),\n  Leaflet Providers contributors [ctb, cph] (Leaflet Providers plugin),\n  Brandon Copeland [ctb, cph] (leaflet-measure plugin),\n  Joerg Dietrich [ctb, cph] (Leaflet.Terminator plugin),\n  Benjamin Becquet [ctb, cph] (Leaflet.MagnifyingGlass plugin),\n  Norkart AS [ctb, cph] (Leaflet.MiniMap plugin),\n  L. Voogdt [ctb, cph] (Leaflet.awesome-markers plugin),\n  Daniel Montague [ctb, cph] (Leaflet.EasyButton plugin),\n  Kartena AB [ctb, cph] (Proj4Leaflet plugin),\n  Robert Kajic [ctb, cph] (leaflet-locationfilter plugin),\n  Mapbox [ctb, cph] (leaflet-omnivore plugin),\n  Michael Bostock [ctb, cph] (topojson),\n  RStudio [cph]",
+        "Repository": "RSPM",
+        "Date/Publication": "2018-08-27 14:12:16 UTC",
+        "Built": "R 3.6.1; ; 2019-09-21 13:25:53 UTC; unix"
       }
     },
     "magrittr": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1292,14 +1330,15 @@
         "ByteCompile": "Yes",
         "Packaged": "2014-11-22 08:50:53 UTC; shb",
         "NeedsCompilation": "no",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2014-11-22 19:15:57",
-        "Built": "R 3.6.0; ; 2019-04-28 14:55:15 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-26 13:36:25 UTC; unix"
       }
     },
     "markdown": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1308,11 +1347,11 @@
         "Package": "markdown",
         "Type": "Package",
         "Title": "Render Markdown with the C Library 'Sundown'",
-        "Version": "1.1",
+        "Version": "1.0",
         "Authors@R": "c(\n   person(\"JJ\", \"Allaire\", role = \"aut\"),\n   person(\"Jeffrey\", \"Horner\", role = \"aut\"),\n   person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\")),\n   person(\"Henrik\", \"Bengtsson\", role = \"ctb\"),\n   person(\"Jim\", \"Hester\", role = \"ctb\"),\n   person(\"Yixuan\", \"Qiu\", role = \"ctb\"),\n   person(\"Kohske\", \"Takahashi\", role = \"ctb\"),\n   person(\"Adam\", \"November\", role = \"ctb\"),\n   person(\"Nacho\", \"Caballero\", role = \"ctb\"),\n   person(\"Jeroen\", \"Ooms\", role = \"ctb\"),\n   person(\"Thomas\", \"Leeper\", role = \"ctb\"),\n   person(\"Joe\", \"Cheng\", role = \"ctb\"),\n   person(\"Andrzej\", \"Oles\", role = \"ctb\"),\n   person(\"Vicent\", \"Marti\", role = c(\"aut\", \"cph\"), comment = \"The Sundown library\"),\n   person(\"Natacha\", \"Porte\", role = c(\"aut\", \"cph\"), comment = \"The Sundown library\"),\n   person(family = \"RStudio\", role = \"cph\")\n   )",
         "Description": "Provides R bindings to the 'Sundown' Markdown rendering library\n    (<https://github.com/vmg/sundown>). Markdown is a plain-text formatting\n    syntax that can be converted to 'XHTML' or other formats. See\n    <http://en.wikipedia.org/wiki/Markdown> for more information about Markdown.",
         "Depends": "R (>= 2.11.1)",
-        "Imports": "utils, xfun, mime (>= 0.3)",
+        "Imports": "utils, mime (>= 0.3)",
         "Suggests": "knitr, RCurl",
         "License": "GPL-2",
         "URL": "https://github.com/rstudio/markdown",
@@ -1321,17 +1360,17 @@
         "RoxygenNote": "6.1.1",
         "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-08-07 15:59:28 UTC; yihui",
+        "Packaged": "2019-06-07 14:17:03 UTC; yihui",
         "Author": "JJ Allaire [aut],\n  Jeffrey Horner [aut],\n  Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Henrik Bengtsson [ctb],\n  Jim Hester [ctb],\n  Yixuan Qiu [ctb],\n  Kohske Takahashi [ctb],\n  Adam November [ctb],\n  Nacho Caballero [ctb],\n  Jeroen Ooms [ctb],\n  Thomas Leeper [ctb],\n  Joe Cheng [ctb],\n  Andrzej Oles [ctb],\n  Vicent Marti [aut, cph] (The Sundown library),\n  Natacha Porte [aut, cph] (The Sundown library),\n  RStudio [cph]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-08-07 16:30:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-06 13:19:18 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-06-07 19:00:15 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-01 20:48:24 UTC; unix"
       }
     },
     "metricsgraphics": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1359,19 +1398,19 @@
         "Repository": "RSPM",
         "Date/Publication": "2015-12-21 15:29:04",
         "Encoding": "UTF-8",
-        "Built": "R 3.6.1; ; 2019-10-22 16:21:28 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-08-03 14:59:33 UTC; unix"
       }
     },
     "mgcv": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
       "GithubSha1": null,
       "description": {
         "Package": "mgcv",
-        "Version": "1.8-31",
+        "Version": "1.8-28",
         "Author": "Simon Wood <simon.wood@r-project.org>",
         "Maintainer": "Simon Wood <simon.wood@r-project.org>",
         "Title": "Mixed GAM Computation Vehicle with Automatic Smoothness\nEstimation",
@@ -1384,15 +1423,16 @@
         "ByteCompile": "yes",
         "License": "GPL (>= 2)",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-11-08 21:21:15 UTC; sw283",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-09 05:30:11 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; \"Sat, 16 Nov 2019 16:30:18 +0000\"; unix"
+        "Packaged": "2019-03-21 08:56:32 UTC; sw283",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-03-21 11:40:07 UTC",
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-19 12:31:01 UTC; unix"
       }
     },
     "mime": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1415,14 +1455,14 @@
         "Packaged": "2019-06-11 19:49:18 UTC; yihui",
         "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Jeffrey Horner [ctb],\n  Beilei Bian [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-06-11 20:10:03 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-07-29 13:46:17 UTC; unix"
+        "Built": "R 3.6.2; x86_64-pc-linux-gnu; 2019-12-27 20:36:28 UTC; unix"
       }
     },
     "munsell": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1442,22 +1482,23 @@
         "RoxygenNote": "6.0.1",
         "NeedsCompilation": "no",
         "Packaged": "2018-06-11 23:15:15 UTC; wickhamc",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-06-12 04:29:06 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 14:57:58 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; ; 2019-09-26 13:33:52 UTC; unix"
       }
     },
     "nlme": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
       "GithubSha1": null,
       "description": {
         "Package": "nlme",
-        "Version": "3.1-142",
-        "Date": "2019-11-07",
+        "Version": "3.1-140",
+        "Date": "2019-05-1",
         "Priority": "recommended",
         "Title": "Linear and Nonlinear Mixed Effects Models",
         "Authors@R": "c(person(\"José\", \"Pinheiro\", role = \"aut\", comment = \"S version\"),\n             person(\"Douglas\", \"Bates\", role = \"aut\", comment = \"up to 2007\"),\n             person(\"Saikat\", \"DebRoy\", role = \"ctb\", comment = \"up to 2002\"),\n             person(\"Deepayan\", \"Sarkar\", role = \"ctb\", comment = \"up to 2005\"),\n             person(\"EISPACK authors\", role = \"ctb\", comment = \"src/rs.f\"),\n\t     person(\"Siem\", \"Heisterkamp\", role = \"ctb\", comment = \"Author fixed sigma\"),\n             person(\"Bert\", \"Van Willigen\",role = \"ctb\", comment = \"Programmer fixed sigma\"),\n\t     person(\"R-core\", email = \"R-core@R-project.org\",\n                    role = c(\"aut\", \"cre\")))",
@@ -1472,17 +1513,17 @@
         "BugReports": "https://bugs.r-project.org",
         "URL": "https://svn.r-project.org/R-packages/trunk/nlme",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-11-07 08:42:14 UTC; maechler",
+        "Packaged": "2019-05-12 07:16:10 UTC; ripley",
         "Author": "José Pinheiro [aut] (S version),\n  Douglas Bates [aut] (up to 2007),\n  Saikat DebRoy [ctb] (up to 2002),\n  Deepayan Sarkar [ctb] (up to 2005),\n  EISPACK authors [ctb] (src/rs.f),\n  Siem Heisterkamp [ctb] (Author fixed sigma),\n  Bert Van Willigen [ctb] (Programmer fixed sigma),\n  R-core [aut, cre]",
         "Maintainer": "R-core <R-core@R-project.org>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-07 18:40:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 'Sun, 10 Nov 2019 15:20:27 +0000'; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-05-12 08:05:27 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-01 20:44:29 UTC; unix"
       }
     },
     "openssl": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1491,7 +1532,7 @@
         "Package": "openssl",
         "Type": "Package",
         "Title": "Toolkit for Encryption, Signatures and Certificates Based on\nOpenSSL",
-        "Version": "1.4.1",
+        "Version": "1.4",
         "Authors@R": "c(person(\"Jeroen\", \"Ooms\", role = c(\"aut\", \"cre\"), email = \"jeroen@berkeley.edu\",\n    comment = c(ORCID = \"0000-0002-4035-0289\")),\n    person(\"Oliver\", \"Keyes\", role = \"ctb\"))",
         "Description": "Bindings to OpenSSL libssl and libcrypto, plus custom SSH key parsers.\n    Supports RSA, DSA and EC curves P-256, P-384, P-521, and curve25519. Cryptographic\n    signatures can either be created and verified manually or via x509 certificates. \n    AES can be used in cbc, ctr or gcm mode for symmetric encryption; RSA for asymmetric\n    (public key) encryption or EC for Diffie Hellman. High-level envelope functions \n    combine RSA and AES for encrypting arbitrary sized data. Other utilities include key\n    generators, hash functions (md5, sha1, sha256, etc), base64 encoder, a secure random\n    number generator, and 'bignum' math methods for manually performing crypto \n    calculations on large multibyte integers.",
         "License": "MIT + file LICENSE",
@@ -1504,17 +1545,17 @@
         "RoxygenNote": "6.1.1",
         "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-07-16 17:55:20 UTC; jeroen",
+        "Packaged": "2019-05-31 20:04:48 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Oliver Keyes [ctb]",
         "Maintainer": "Jeroen Ooms <jeroen@berkeley.edu>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-07-18 06:35:27 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-03 14:28:49 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-05-31 21:30:12 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-05 14:49:42 UTC; unix"
       }
     },
     "pillar": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1538,9 +1579,9 @@
         "Packaged": "2019-06-29 16:08:04 UTC; kirill",
         "Author": "Kirill Müller [aut, cre],\n  Hadley Wickham [aut],\n  RStudio [cph]",
         "Maintainer": "Kirill Müller <krlmlr+r@mailbox.org>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-06-29 16:40:03 UTC",
-        "Built": "R 3.6.0; ; 2019-07-01 16:53:33 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-26 13:45:50 UTC; unix"
       }
     },
     "pins": {
@@ -1549,12 +1590,12 @@
       "GithubRepo": "pins",
       "GithubUsername": "rstudio",
       "GithubRef": "master",
-      "GithubSha1": "a43f3d3ea9b4899f2887a2a59f119c8653a48ad0",
+      "GithubSha1": "e826fea0281e796ef5359a708ffc46d80b546a7c",
       "description": {
         "Package": "pins",
         "Type": "Package",
         "Title": "Pin, Discover and Share Resources",
-        "Version": "0.3.0.9000",
+        "Version": "0.2.0.0004",
         "Authors@R": "c(\n    person(\"Javier\", \"Luraschi\", email = \"javier@rstudio.com\", role = c(\"aut\", \"cre\")),\n    person(family = \"RStudio\", role = c(\"cph\"))\n    )",
         "Maintainer": "Javier Luraschi <javier@rstudio.com>",
         "Description": "Pin remote resources into a local cache to work offline,\n  improve speed and avoid recomputing; discover and share resources\n  in local folders, 'GitHub', 'Kaggle' or 'RStudio Connect'. Resources can \n  be anything from 'CSV', 'JSON', or image files to arbitrary R objects.",
@@ -1563,7 +1604,7 @@
         "LazyData": "true",
         "RoxygenNote": "6.1.1",
         "Depends": "R (>= 3.2.0)",
-        "Imports": "base64enc, crayon, httr, jsonlite, magrittr, mime, openssl,\nrappdirs, withr, yaml, zip",
+        "Imports": "base64enc, httr, jsonlite, magrittr, mime, openssl, rappdirs,\nwithr, yaml, zip",
         "Suggests": "knitr, rmarkdown, R6, testthat",
         "VignetteBuilder": "knitr",
         "URL": "https://github.com/rstudio/pins",
@@ -1573,20 +1614,20 @@
         "RemoteRepo": "pins",
         "RemoteUsername": "rstudio",
         "RemoteRef": "master",
-        "RemoteSha": "a43f3d3ea9b4899f2887a2a59f119c8653a48ad0",
+        "RemoteSha": "e826fea0281e796ef5359a708ffc46d80b546a7c",
         "GithubRepo": "pins",
         "GithubUsername": "rstudio",
         "GithubRef": "master",
-        "GithubSHA1": "a43f3d3ea9b4899f2887a2a59f119c8653a48ad0",
+        "GithubSHA1": "e826fea0281e796ef5359a708ffc46d80b546a7c",
         "NeedsCompilation": "no",
-        "Packaged": "2019-12-12 17:58:40 UTC; edgar",
+        "Packaged": "2019-11-08 01:28:59 UTC; james",
         "Author": "Javier Luraschi [aut, cre],\n  RStudio [cph]",
-        "Built": "R 3.6.1; ; 2019-12-12 17:58:42 UTC; unix"
+        "Built": "R 3.6.0; ; 2019-11-08 01:29:00 UTC; unix"
       }
     },
     "pkgconfig": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1609,12 +1650,12 @@
         "Packaged": "2019-09-22 08:42:40 UTC; gaborcsardi",
         "Repository": "RSPM",
         "Date/Publication": "2019-09-22 09:20:02 UTC",
-        "Built": "R 3.6.1; ; 2019-09-24 20:01:15 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-26 13:37:56 UTC; unix"
       }
     },
     "plogr": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1637,14 +1678,14 @@
         "Packaged": "2018-03-24 11:02:06 UTC; muelleki",
         "Author": "Kirill Müller [aut, cre],\n  Sergey Podobry [cph] (Author of the bundled plog library)",
         "Maintainer": "Kirill Müller <krlmlr+r@mailbox.org>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-03-25 15:25:27 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 14:53:11 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-26 13:37:57 UTC; unix"
       }
     },
     "plyr": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1668,14 +1709,15 @@
         "Packaged": "2016-06-07 19:58:36 UTC; hadley",
         "Author": "Hadley Wickham [aut, cre]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2016-06-08 10:40:15",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 14:59:31 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-05 07:57:22 UTC; unix"
       }
     },
     "png": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1693,14 +1735,45 @@
         "URL": "http://www.rforge.net/png/",
         "Packaged": "2013-12-03 20:09:14 UTC; svnuser",
         "NeedsCompilation": "yes",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2013-12-03 22:25:05",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 19:57:38 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:33:57 UTC; unix"
+      }
+    },
+    "processx": {
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "processx",
+        "Title": "Execute and Control System Processes",
+        "Version": "3.4.1",
+        "Authors@R": "c(\n    person(\"Gábor\", \"Csárdi\", role = c(\"aut\", \"cre\", \"cph\"),\n           email = \"csardi.gabor@gmail.com\",\n\t   comment = c(ORCID = \"0000-0001-7098-9676\")),\n    person(\"Winston\", \"Chang\", role = \"aut\"),\n    person(\"RStudio\", role = c(\"cph\", \"fnd\")),\n    person(\"Mango Solutions\", role  = c(\"cph\", \"fnd\")))",
+        "Description": "Tools to run system processes in the background.\n    It can check if a background process is running; wait on a background\n    process to finish; get the exit status of finished processes; kill\n    background processes. It can read the standard output and error of\n    the processes, using non-blocking connections. 'processx' can poll\n    a process for standard output or error, with a timeout. It can also\n    poll several processes at once.",
+        "License": "MIT + file LICENSE",
+        "LazyData": "true",
+        "URL": "https://processx.r-lib.org,\nhttps://github.com/r-lib/processx#readme",
+        "BugReports": "https://github.com/r-lib/processx/issues",
+        "RoxygenNote": "6.1.1",
+        "Imports": "ps (>= 1.2.0), R6, utils",
+        "Suggests": "callr (>= 3.2.0), codetools, covr, crayon, curl, debugme,\nparallel, testthat, withr",
+        "Encoding": "UTF-8",
+        "NeedsCompilation": "yes",
+        "Packaged": "2019-07-16 14:54:16 UTC; gaborcsardi",
+        "Author": "Gábor Csárdi [aut, cre, cph] (<https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  RStudio [cph, fnd],\n  Mango Solutions [cph, fnd]",
+        "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-07-18 06:35:54 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:42:12 UTC; unix"
       }
     },
     "promises": {
       "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1728,12 +1801,43 @@
         "Maintainer": "Joe Cheng <joe@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2019-10-04 23:00:05 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 20:01:26 UTC; unix"
+        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-11-08 21:28:54 UTC; unix"
+      }
+    },
+    "ps": {
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "ps",
+        "Version": "1.3.0",
+        "Title": "List, Query, Manipulate System Processes",
+        "Description": "List, query and manipulate all system processes, on 'Windows',\n    'Linux' and 'macOS'.",
+        "Authors@R": "c(\n    person(\"Jay\", \"Loden\", role = \"aut\"),\n    person(\"Dave\", \"Daeschler\", role = \"aut\"),\n    person(\"Giampaolo\", \"Rodola'\", role = \"aut\"),\n    person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", c(\"aut\", \"cre\")),\n    person(\"RStudio\", role = \"cph\"))",
+        "License": "BSD_3_clause + file LICENSE",
+        "URL": "https://github.com/r-lib/ps#readme",
+        "BugReports": "https://github.com/r-lib/ps/issues",
+        "Encoding": "UTF-8",
+        "Depends": "R (>= 3.1)",
+        "Imports": "utils",
+        "Suggests": "callr, covr, curl, pingr, processx (>= 3.1.0), R6, rlang,\ntestthat, tibble",
+        "RoxygenNote": "6.1.1",
+        "Biarch": "true",
+        "NeedsCompilation": "yes",
+        "Packaged": "2018-12-20 20:34:33 UTC; gaborcsardi",
+        "Author": "Jay Loden [aut],\n  Dave Daeschler [aut],\n  Giampaolo Rodola' [aut],\n  Gábor Csárdi [aut, cre],\n  RStudio [cph]",
+        "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
+        "Repository": "RSPM",
+        "Date/Publication": "2018-12-21 14:50:03 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:38:49 UTC; unix"
       }
     },
     "purrr": {
       "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1758,14 +1862,14 @@
         "Packaged": "2019-10-17 08:02:23 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  RStudio [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@rstudio.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2019-10-18 12:40:05 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-12-05 14:35:05 UTC; unix"
+        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-11-08 21:28:40 UTC; unix"
       }
     },
     "rappdirs": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1788,14 +1892,15 @@
         "Packaged": "2016-03-28 19:04:15 UTC; hadley",
         "Author": "Hadley Wickham [trl, cre, cph],\n  RStudio [cph],\n  Sridhar Ratnakumar [aut],\n  Trent Mick [aut],\n  ActiveState [cph] (R/appdir.r, R/cache.r, R/data.r, R/log.r translated\n    from appdirs),\n  Eddy Petrisor [ctb],\n  Trevor Davis [trl, aut],\n  Gabor Csardi [ctb],\n  Gregory Jefferis [ctb]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2016-03-28 23:10:10",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 14:55:26 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:34:49 UTC; unix"
       }
     },
     "raster": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1804,8 +1909,8 @@
         "Package": "raster",
         "Type": "Package",
         "Title": "Geographic Data Analysis and Modeling",
-        "Version": "3.0-7",
-        "Date": "2019-09-22",
+        "Version": "2.9-23",
+        "Date": "2019-07-10",
         "Depends": "sp (>= 1.2-0), R (>= 3.0.0)",
         "Suggests": "rgdal (>= 0.9-1), rgeos (>= 0.3-8), ncdf4, igraph, tcltk,\nparallel, rasterVis, MASS, sf, testthat",
         "LinkingTo": "Rcpp",
@@ -1817,17 +1922,48 @@
         "BugReports": "https://github.com/rspatial/raster/issues/",
         "Authors@R": "c(\n\tperson(\"Robert J.\", \"Hijmans\", role = c(\"cre\", \"aut\"),  \n\t\t\temail = \"r.hijmans@gmail.com\", \n\t\t\tcomment = c(ORCID = \"0000-0001-5872-2872\")),\n\tperson(\"Jacob\", \"van Etten\", role = \"ctb\"),\n\tperson(\"Michael\", \"Sumner\", role = \"ctb\"),\n\tperson(\"Joe\", \"Cheng\", role = \"ctb\"),\n\tperson(\"Andrew\", \"Bevan\", role = \"ctb\"),\n\tperson(\"Roger\", \"Bivand\", role = \"ctb\"),\n\tperson(\"Lorenzo\", \"Busetto\", role = \"ctb\"),\n\tperson(\"Mort\", \"Canty\", role = \"ctb\"),\n\tperson(\"David\", \"Forrest\", role = \"ctb\"),\n\tperson(\"Aniruddha\", \"Ghosh\", role = \"ctb\"),\n\tperson(\"Duncan\", \"Golicher\", role = \"ctb\"),\n\tperson(\"Josh\", \"Gray\", role = \"ctb\"),\n\tperson(\"Jonathan A.\", \"Greenberg\", role = \"ctb\"),\n\tperson(\"Paul\", \"Hiemstra\", role = \"ctb\"),\n\tperson(\"Institute for Mathematics Applied Geosciences\", role=\"cph\"),\n\tperson(\"Charles\", \"Karney\", role = \"ctb\"),\n\tperson(\"Matteo\", \"Mattiuzzi\", role = \"ctb\"),\n\tperson(\"Steven\", \"Mosher\", role = \"ctb\"),\n\tperson(\"Jakub\", \"Nowosad\", role = \"ctb\"),\n\tperson(\"Edzer\", \"Pebesma\", role = \"ctb\"),\n\tperson(\"Oscar\", \"Perpinan Lamigueiro\", role = \"ctb\"),\n\tperson(\"Etienne B.\", \"Racine\", role = \"ctb\"),\n\tperson(\"Barry\", \"Rowlingson\", role = \"ctb\"),\n\tperson(\"Ashton\", \"Shortridge\", role = \"ctb\"),\n\tperson(\"Bill\", \"Venables\", role = \"ctb\"),\n\tperson(\"Rafael\", \"Wueest\", role = \"ctb\")\n\t)",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-09-22 16:57:11 UTC; rhijm",
+        "Packaged": "2019-07-11 05:48:54 UTC; rhijm",
         "Author": "Robert J. Hijmans [cre, aut] (<https://orcid.org/0000-0001-5872-2872>),\n  Jacob van Etten [ctb],\n  Michael Sumner [ctb],\n  Joe Cheng [ctb],\n  Andrew Bevan [ctb],\n  Roger Bivand [ctb],\n  Lorenzo Busetto [ctb],\n  Mort Canty [ctb],\n  David Forrest [ctb],\n  Aniruddha Ghosh [ctb],\n  Duncan Golicher [ctb],\n  Josh Gray [ctb],\n  Jonathan A. Greenberg [ctb],\n  Paul Hiemstra [ctb],\n  Institute for Mathematics Applied Geosciences [cph],\n  Charles Karney [ctb],\n  Matteo Mattiuzzi [ctb],\n  Steven Mosher [ctb],\n  Jakub Nowosad [ctb],\n  Edzer Pebesma [ctb],\n  Oscar Perpinan Lamigueiro [ctb],\n  Etienne B. Racine [ctb],\n  Barry Rowlingson [ctb],\n  Ashton Shortridge [ctb],\n  Bill Venables [ctb],\n  Rafael Wueest [ctb]",
         "Maintainer": "Robert J. Hijmans <r.hijmans@gmail.com>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-09-24 15:40:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 19:53:51 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-07-11 13:43:08 UTC",
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-05 18:03:02 UTC; unix"
+      }
+    },
+    "rematch2": {
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "rematch2",
+        "Title": "Tidy Output from Regular Expression Matching",
+        "Version": "2.1.0",
+        "Authors@R": "c(\n    person(\"Gábor\", \"Csárdi\", email = \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\")),\n    person(\"Matthew\", \"Lincoln\", email = \"matthew.d.lincoln@gmail.com\", role = c(\"ctb\")))",
+        "Description": "Wrappers on 'regexpr' and 'gregexpr' to return the match\n    results in tidy data frames.",
+        "License": "MIT + file LICENSE",
+        "LazyData": "true",
+        "URL": "https://github.com/r-lib/rematch2#readme",
+        "BugReports": "https://github.com/r-lib/rematch2/issues",
+        "RoxygenNote": "6.0.1",
+        "Imports": "tibble",
+        "Suggests": "covr, testthat",
+        "Encoding": "UTF-8",
+        "NeedsCompilation": "no",
+        "Packaged": "2019-07-11 16:40:34 UTC; gaborcsardi",
+        "Author": "Gábor Csárdi [aut, cre],\n  Matthew Lincoln [ctb]",
+        "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-07-11 17:32:41 UTC",
+        "Built": "R 3.6.1; ; 2019-09-26 13:46:41 UTC; unix"
       }
     },
     "reshape2": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1851,14 +1987,14 @@
         "RoxygenNote": "6.0.1.9000",
         "NeedsCompilation": "yes",
         "Packaged": "2017-12-10 22:04:42 UTC; hadley",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2017-12-11 16:47:57 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 15:02:24 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-05 08:07:21 UTC; unix"
       }
     },
     "rlang": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1883,14 +2019,14 @@
         "Packaged": "2019-11-22 16:01:18 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  RStudio [cph]",
         "Maintainer": "Lionel Henry <lionel@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-11-23 11:20:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 19:51:36 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-25 16:54:12 UTC; unix"
       }
     },
     "rmarkdown": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1899,8 +2035,8 @@
         "Package": "rmarkdown",
         "Type": "Package",
         "Title": "Dynamic Documents for R",
-        "Version": "1.17",
-        "Authors@R": "c(\n  person(\"JJ\", \"Allaire\", role = \"aut\", email = \"jj@rstudio.com\"),\n  person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\")),\n  person(\"Jonathan\", \"McPherson\", role = \"aut\", email = \"jonathan@rstudio.com\"),\n  person(\"Javier\", \"Luraschi\", role = \"aut\", email = \"javier@rstudio.com\"),\n  person(\"Kevin\", \"Ushey\", role = \"aut\", email = \"kevin@rstudio.com\"),\n  person(\"Aron\", \"Atkins\", role = \"aut\", email = \"aron@rstudio.com\"),\n  person(\"Hadley\", \"Wickham\", role = \"aut\", email = \"hadley@rstudio.com\"),\n  person(\"Joe\", \"Cheng\", role = \"aut\", email = \"joe@rstudio.com\"),\n  person(\"Winston\", \"Chang\", role = \"aut\", email = \"winston@rstudio.com\"),\n  person(\"Richard\", \"Iannone\", role = \"aut\", email = \"rich@rstudio.com\", comment = c(ORCID = \"0000-0003-3925-190X\")),\n  #\n  # Contributors, ordered alphabetically by first name\n  person(\"Atsushi\", \"Yasumoto\", role = \"ctb\", comment = c(ORCID = \"0000-0002-8335-495X\")),\n  person(\"Barret\", \"Schloerke\", role = \"ctb\"),\n  person(\"Christophe\", \"Dervieux\", role = \"ctb\"),\n  person(\"Frederik\", \"Aust\", role = \"ctb\", email = \"frederik.aust@uni-koeln.de\", comment = c(ORCID = \"0000-0003-4900-788X\")),\n  person(\"Jeff\", \"Allen\", role = \"ctb\", email = \"jeff@rstudio.com\"),\n  person(\"Malcolm\", \"Barrett\", role = \"ctb\"),\n  person(\"Rob\", \"Hyndman\", role = \"ctb\", email = \"Rob.Hyndman@monash.edu\"),\n  person(\"Romain\", \"Lesur\", role = \"ctb\"),\n  person(\"Roy\", \"Storey\", role = \"ctb\"),\n  person(\"Ruben\", \"Arslan\", role = \"ctb\", email = \"ruben.arslan@uni-goettingen.de\"),\n  #\n  # Copyright holders\n  person(family = \"RStudio, Inc.\", role = \"cph\"),\n  person(family = \"jQuery Foundation\", role = \"cph\",\n         comment = \"jQuery library\"),\n  person(family = \"jQuery contributors\", role = c(\"ctb\", \"cph\"),\n         comment = \"jQuery library; authors listed in inst/rmd/h/jquery-AUTHORS.txt\"),\n  person(family = \"jQuery UI contributors\", role = c(\"ctb\", \"cph\"),\n         comment = \"jQuery UI library; authors listed in inst/rmd/h/jqueryui-AUTHORS.txt\"),\n  person(\"Mark\", \"Otto\", role = \"ctb\",\n         comment = \"Bootstrap library\"),\n  person(\"Jacob\", \"Thornton\", role = \"ctb\",\n         comment = \"Bootstrap library\"),\n  person(family = \"Bootstrap contributors\", role = \"ctb\",\n         comment = \"Bootstrap library\"),\n  person(family = \"Twitter, Inc\", role = \"cph\",\n         comment = \"Bootstrap library\"),\n  person(\"Alexander\", \"Farkas\", role = c(\"ctb\", \"cph\"),\n         comment = \"html5shiv library\"),\n  person(\"Scott\", \"Jehl\", role = c(\"ctb\", \"cph\"),\n         comment = \"Respond.js library\"),\n  person(\"Ivan\", \"Sagalaev\", role = c(\"ctb\", \"cph\"),\n         comment = \"highlight.js library\"),\n  person(\"Greg\", \"Franko\", role = c(\"ctb\", \"cph\"),\n         comment = \"tocify library\"),\n  person(\"John\", \"MacFarlane\", role = c(\"ctb\", \"cph\"),\n         comment = \"Pandoc templates\"),\n  person(family = \"Google, Inc.\", role = c(\"ctb\", \"cph\"),\n         comment = \"ioslides library\"),\n  person(\"Dave\", \"Raggett\", role = \"ctb\",\n         comment = \"slidy library\"),\n  person(family = \"W3C\", role = \"cph\",\n         comment = \"slidy library\"),\n  person(\"Dave\", \"Gandy\", role = c(\"ctb\", \"cph\"),\n         comment = \"Font-Awesome\"),\n  person(\"Ben\", \"Sperry\", role = \"ctb\",\n         comment = \"Ionicons\"),\n  person(family = \"Drifty\", role = \"cph\",\n         comment = \"Ionicons\"),\n  person(\"Aidan\", \"Lister\", role = c(\"ctb\", \"cph\"), \n         comment = \"jQuery StickyTabs\"),\n  person(\"Benct Philip\", \"Jonsson\", role = c(\"ctb\", \"cph\"), \n         comment = \"pagebreak lua filter\"),\n  person(\"Albert\", \"Krewinkel\", role = c(\"ctb\", \"cph\"), \n         comment = \"pagebreak lua filter\")\n  )",
+        "Version": "1.14",
+        "Authors@R": "c(\n  person(\"JJ\", \"Allaire\", role = \"aut\", email = \"jj@rstudio.com\"),\n  person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\")),\n  person(\"Jonathan\", \"McPherson\", role = \"aut\", email = \"jonathan@rstudio.com\"),\n  person(\"Javier\", \"Luraschi\", role = \"aut\", email = \"javier@rstudio.com\"),\n  person(\"Kevin\", \"Ushey\", role = \"aut\", email = \"kevin@rstudio.com\"),\n  person(\"Aron\", \"Atkins\", role = \"aut\", email = \"aron@rstudio.com\"),\n  person(\"Hadley\", \"Wickham\", role = \"aut\", email = \"hadley@rstudio.com\"),\n  person(\"Joe\", \"Cheng\", role = \"aut\", email = \"joe@rstudio.com\"),\n  person(\"Winston\", \"Chang\", role = \"aut\", email = \"winston@rstudio.com\"),\n  person(\"Richard\", \"Iannone\", role = \"aut\", email = \"rich@rstudio.com\", comment = c(ORCID = \"0000-0003-3925-190X\")),\n  #\n  # Contributors, ordered alphabetically by first name\n  person(\"Barret\", \"Schloerke\", role = \"ctb\"),\n  person(\"Christophe\", \"Dervieux\", role = \"ctb\"),\n  person(\"Frederik\", \"Aust\", role = \"ctb\", email = \"frederik.aust@uni-koeln.de\", comment = c(ORCID = \"0000-0003-4900-788X\")),\n  person(\"Jeff\", \"Allen\", role = \"ctb\", email = \"jeff@rstudio.com\"),\n  person(\"Malcolm\", \"Barrett\", role = \"ctb\"),\n  person(\"Rob\", \"Hyndman\", role = \"ctb\", email = \"Rob.Hyndman@monash.edu\"),\n  person(\"Romain\", \"Lesur\", role = \"ctb\"),\n  person(\"Roy\", \"Storey\", role = \"ctb\"),\n  person(\"Ruben\", \"Arslan\", role = \"ctb\", email = \"ruben.arslan@uni-goettingen.de\"),\n  #\n  # Copyright holders\n  person(family = \"RStudio, Inc.\", role = \"cph\"),\n  person(family = \"jQuery Foundation\", role = \"cph\",\n         comment = \"jQuery library\"),\n  person(family = \"jQuery contributors\", role = c(\"ctb\", \"cph\"),\n         comment = \"jQuery library; authors listed in inst/rmd/h/jquery-AUTHORS.txt\"),\n  person(family = \"jQuery UI contributors\", role = c(\"ctb\", \"cph\"),\n         comment = \"jQuery UI library; authors listed in inst/rmd/h/jqueryui-AUTHORS.txt\"),\n  person(\"Mark\", \"Otto\", role = \"ctb\",\n         comment = \"Bootstrap library\"),\n  person(\"Jacob\", \"Thornton\", role = \"ctb\",\n         comment = \"Bootstrap library\"),\n  person(family = \"Bootstrap contributors\", role = \"ctb\",\n         comment = \"Bootstrap library\"),\n  person(family = \"Twitter, Inc\", role = \"cph\",\n         comment = \"Bootstrap library\"),\n  person(\"Alexander\", \"Farkas\", role = c(\"ctb\", \"cph\"),\n         comment = \"html5shiv library\"),\n  person(\"Scott\", \"Jehl\", role = c(\"ctb\", \"cph\"),\n         comment = \"Respond.js library\"),\n  person(\"Ivan\", \"Sagalaev\", role = c(\"ctb\", \"cph\"),\n         comment = \"highlight.js library\"),\n  person(\"Greg\", \"Franko\", role = c(\"ctb\", \"cph\"),\n         comment = \"tocify library\"),\n  person(\"John\", \"MacFarlane\", role = c(\"ctb\", \"cph\"),\n         comment = \"Pandoc templates\"),\n  person(family = \"Google, Inc.\", role = c(\"ctb\", \"cph\"),\n         comment = \"ioslides library\"),\n  person(\"Dave\", \"Raggett\", role = \"ctb\",\n         comment = \"slidy library\"),\n  person(family = \"W3C\", role = \"cph\",\n         comment = \"slidy library\"),\n  person(\"Dave\", \"Gandy\", role = c(\"ctb\", \"cph\"),\n         comment = \"Font-Awesome\"),\n  person(\"Ben\", \"Sperry\", role = \"ctb\",\n         comment = \"Ionicons\"),\n  person(family = \"Drifty\", role = \"cph\",\n         comment = \"Ionicons\"),\n  person(\"Aidan\", \"Lister\", role = c(\"ctb\", \"cph\"), \n         comment = \"jQuery StickyTabs\")\n  )",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Description": "Convert R Markdown documents into a variety of formats.",
         "Depends": "R (>= 3.0)",
@@ -1914,16 +2050,49 @@
         "Encoding": "UTF-8",
         "VignetteBuilder": "knitr",
         "NeedsCompilation": "no",
-        "Packaged": "2019-11-11 17:10:34 UTC; yihui",
-        "Author": "JJ Allaire [aut],\n  Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Jonathan McPherson [aut],\n  Javier Luraschi [aut],\n  Kevin Ushey [aut],\n  Aron Atkins [aut],\n  Hadley Wickham [aut],\n  Joe Cheng [aut],\n  Winston Chang [aut],\n  Richard Iannone [aut] (<https://orcid.org/0000-0003-3925-190X>),\n  Atsushi Yasumoto [ctb] (<https://orcid.org/0000-0002-8335-495X>),\n  Barret Schloerke [ctb],\n  Christophe Dervieux [ctb],\n  Frederik Aust [ctb] (<https://orcid.org/0000-0003-4900-788X>),\n  Jeff Allen [ctb],\n  Malcolm Barrett [ctb],\n  Rob Hyndman [ctb],\n  Romain Lesur [ctb],\n  Roy Storey [ctb],\n  Ruben Arslan [ctb],\n  RStudio, Inc. [cph],\n  jQuery Foundation [cph] (jQuery library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/rmd/h/jquery-AUTHORS.txt),\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/rmd/h/jqueryui-AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Alexander Farkas [ctb, cph] (html5shiv library),\n  Scott Jehl [ctb, cph] (Respond.js library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  Greg Franko [ctb, cph] (tocify library),\n  John MacFarlane [ctb, cph] (Pandoc templates),\n  Google, Inc. [ctb, cph] (ioslides library),\n  Dave Raggett [ctb] (slidy library),\n  W3C [cph] (slidy library),\n  Dave Gandy [ctb, cph] (Font-Awesome),\n  Ben Sperry [ctb] (Ionicons),\n  Drifty [cph] (Ionicons),\n  Aidan Lister [ctb, cph] (jQuery StickyTabs),\n  Benct Philip Jonsson [ctb, cph] (pagebreak lua filter),\n  Albert Krewinkel [ctb, cph] (pagebreak lua filter)",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-13 17:00:02 UTC",
-        "Built": "R 3.6.1; ; 2019-12-12 00:59:13 UTC; unix"
+        "Packaged": "2019-07-12 02:57:15 UTC; yihui",
+        "Author": "JJ Allaire [aut],\n  Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Jonathan McPherson [aut],\n  Javier Luraschi [aut],\n  Kevin Ushey [aut],\n  Aron Atkins [aut],\n  Hadley Wickham [aut],\n  Joe Cheng [aut],\n  Winston Chang [aut],\n  Richard Iannone [aut] (<https://orcid.org/0000-0003-3925-190X>),\n  Barret Schloerke [ctb],\n  Christophe Dervieux [ctb],\n  Frederik Aust [ctb] (<https://orcid.org/0000-0003-4900-788X>),\n  Jeff Allen [ctb],\n  Malcolm Barrett [ctb],\n  Rob Hyndman [ctb],\n  Romain Lesur [ctb],\n  Roy Storey [ctb],\n  Ruben Arslan [ctb],\n  RStudio, Inc. [cph],\n  jQuery Foundation [cph] (jQuery library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/rmd/h/jquery-AUTHORS.txt),\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/rmd/h/jqueryui-AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Alexander Farkas [ctb, cph] (html5shiv library),\n  Scott Jehl [ctb, cph] (Respond.js library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  Greg Franko [ctb, cph] (tocify library),\n  John MacFarlane [ctb, cph] (Pandoc templates),\n  Google, Inc. [ctb, cph] (ioslides library),\n  Dave Raggett [ctb] (slidy library),\n  W3C [cph] (slidy library),\n  Dave Gandy [ctb, cph] (Font-Awesome),\n  Ben Sperry [ctb] (Ionicons),\n  Drifty [cph] (Ionicons),\n  Aidan Lister [ctb, cph] (jQuery StickyTabs)",
+        "Repository": "RSPM",
+        "Date/Publication": "2019-07-12 04:43:08 UTC",
+        "Built": "R 3.6.1; ; 2019-08-01 20:51:15 UTC; unix"
+      }
+    },
+    "rprojroot": {
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "rprojroot",
+        "Title": "Finding Files in Project Subdirectories",
+        "Version": "1.3-2",
+        "Authors@R": "person(given = \"Kirill\", family = \"Müller\", role = c(\"aut\",\n        \"cre\"), email = \"krlmlr+r@mailbox.org\")",
+        "Description": "Robust, reliable and flexible paths to files below a\n    project root. The 'root' of a project is defined as a directory\n    that matches a certain criterion, e.g., it contains a certain\n    regular file.",
+        "Depends": "R (>= 3.0.0)",
+        "Imports": "backports",
+        "Suggests": "testthat, mockr, knitr, withr, rmarkdown",
+        "VignetteBuilder": "knitr",
+        "License": "GPL-3",
+        "LazyData": "true",
+        "Encoding": "UTF-8",
+        "URL": "https://github.com/krlmlr/rprojroot,\nhttps://krlmlr.github.io/rprojroot",
+        "BugReports": "https://github.com/krlmlr/rprojroot/issues",
+        "RoxygenNote": "6.0.1",
+        "Collate": "'rrmake.R' 'criterion.R' 'file.R' 'has-file.R' 'root.R'\n'rprojroot-package.R' 'shortcut.R' 'thisfile.R'",
+        "NeedsCompilation": "no",
+        "Packaged": "2018-01-03 13:27:15 UTC; muelleki",
+        "Author": "Kirill Müller [aut, cre]",
+        "Maintainer": "Kirill Müller <krlmlr+r@mailbox.org>",
+        "Repository": "RSPM",
+        "Date/Publication": "2018-01-03 15:36:24 UTC",
+        "Built": "R 3.6.1; ; 2019-09-26 13:33:38 UTC; unix"
       }
     },
     "scales": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -1931,62 +2100,114 @@
       "description": {
         "Package": "scales",
         "Title": "Scale Functions for Visualization",
-        "Version": "1.1.0",
-        "Authors@R": "\n    c(person(given = \"Hadley\",\n             family = \"Wickham\",\n             role = c(\"aut\", \"cre\"),\n             email = \"hadley@rstudio.com\"),\n      person(given = \"Dana\",\n             family = \"Seidel\",\n             role = \"aut\"),\n      person(given = \"RStudio\",\n             role = \"cph\"))",
-        "Description": "Graphical scales map data to aesthetics, and\n    provide methods for automatically determining breaks and labels for\n    axes and legends.",
+        "Version": "1.0.0",
+        "Authors@R": "c(\n    person(\"Hadley\", \"Wickham\", , \"hadley@rstudio.com\", c(\"aut\", \"cre\")),\n    person(\"RStudio\", role = \"cph\")\n    )",
+        "Description": "Graphical scales map data to aesthetics, and provide\n    methods for automatically determining breaks and labels\n    for axes and legends.",
         "License": "MIT + file LICENSE",
         "URL": "https://scales.r-lib.org, https://github.com/r-lib/scales",
         "BugReports": "https://github.com/r-lib/scales/issues",
-        "Depends": "R (>= 3.2)",
-        "Imports": "farver (>= 2.0.0), labeling, munsell (>= 0.5), R6,\nRColorBrewer, viridisLite, lifecycle",
-        "Suggests": "bit64, covr, dichromat, hms, testthat (>= 2.1.0), ggplot2",
-        "Encoding": "UTF-8",
+        "Depends": "R (>= 3.1)",
+        "Imports": "labeling, munsell (>= 0.5), R6, RColorBrewer, Rcpp,\nviridisLite",
+        "Suggests": "dichromat, bit64, covr, hms, testthat (>= 2.0)",
+        "LinkingTo": "Rcpp",
         "LazyLoad": "yes",
-        "RoxygenNote": "6.1.1",
-        "NeedsCompilation": "no",
-        "Packaged": "2019-11-18 14:21:37 UTC; hadley",
-        "Author": "Hadley Wickham [aut, cre],\n  Dana Seidel [aut],\n  RStudio [cph]",
+        "RoxygenNote": "6.0.1.9000",
+        "Encoding": "UTF-8",
+        "NeedsCompilation": "yes",
+        "Packaged": "2018-08-07 18:17:33 UTC; hadley",
+        "Author": "Hadley Wickham [aut, cre],\n  RStudio [cph]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-18 16:10:05 UTC",
-        "Built": "R 3.6.1; ; 2019-11-23 19:56:44 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2018-08-09 10:10:03 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-05 08:08:58 UTC; unix"
       }
     },
     "shiny": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "GithubRepo": null,
-      "GithubUsername": null,
-      "GithubRef": null,
-      "GithubSha1": null,
+      "Source": "github",
+      "Repository": null,
+      "GithubRepo": "shiny",
+      "GithubUsername": "rstudio",
+      "GithubRef": "master",
+      "GithubSha1": "e07c7483a79cc641d464cd7496872a28eedbe4a4",
       "description": {
         "Package": "shiny",
         "Type": "Package",
         "Title": "Web Application Framework for R",
-        "Version": "1.4.0",
+        "Version": "1.4.0.9001",
         "Authors@R": "c(\n    person(\"Winston\", \"Chang\", role = c(\"aut\", \"cre\"), email = \"winston@rstudio.com\"),\n    person(\"Joe\", \"Cheng\", role = \"aut\", email = \"joe@rstudio.com\"),\n    person(\"JJ\", \"Allaire\", role = \"aut\", email = \"jj@rstudio.com\"),\n    person(\"Yihui\", \"Xie\", role = \"aut\", email = \"yihui@rstudio.com\"),\n    person(\"Jonathan\", \"McPherson\", role = \"aut\", email = \"jonathan@rstudio.com\"),\n    person(family = \"RStudio\", role = \"cph\"),\n    person(family = \"jQuery Foundation\", role = \"cph\",\n    comment = \"jQuery library and jQuery UI library\"),\n    person(family = \"jQuery contributors\", role = c(\"ctb\", \"cph\"),\n    comment = \"jQuery library; authors listed in inst/www/shared/jquery-AUTHORS.txt\"),\n    person(family = \"jQuery UI contributors\", role = c(\"ctb\", \"cph\"),\n    comment = \"jQuery UI library; authors listed in inst/www/shared/jqueryui/AUTHORS.txt\"),\n    person(\"Mark\", \"Otto\", role = \"ctb\",\n    comment = \"Bootstrap library\"),\n    person(\"Jacob\", \"Thornton\", role = \"ctb\",\n    comment = \"Bootstrap library\"),\n    person(family = \"Bootstrap contributors\", role = \"ctb\",\n    comment = \"Bootstrap library\"),\n    person(family = \"Twitter, Inc\", role = \"cph\",\n    comment = \"Bootstrap library\"),\n    person(\"Alexander\", \"Farkas\", role = c(\"ctb\", \"cph\"),\n    comment = \"html5shiv library\"),\n    person(\"Scott\", \"Jehl\", role = c(\"ctb\", \"cph\"),\n    comment = \"Respond.js library\"),\n    person(\"Stefan\", \"Petre\", role = c(\"ctb\", \"cph\"),\n    comment = \"Bootstrap-datepicker library\"),\n    person(\"Andrew\", \"Rowls\", role = c(\"ctb\", \"cph\"),\n    comment = \"Bootstrap-datepicker library\"),\n    person(\"Dave\", \"Gandy\", role = c(\"ctb\", \"cph\"),\n    comment = \"Font-Awesome font\"),\n    person(\"Brian\", \"Reavis\", role = c(\"ctb\", \"cph\"),\n    comment = \"selectize.js library\"),\n    person(\"Kristopher Michael\", \"Kowal\", role = c(\"ctb\", \"cph\"),\n    comment = \"es5-shim library\"),\n    person(family = \"es5-shim contributors\", role = c(\"ctb\", \"cph\"),\n    comment = \"es5-shim library\"),\n    person(\"Denis\", \"Ineshin\", role = c(\"ctb\", \"cph\"),\n    comment = \"ion.rangeSlider library\"),\n    person(\"Sami\", \"Samhuri\", role = c(\"ctb\", \"cph\"),\n    comment = \"Javascript strftime library\"),\n    person(family = \"SpryMedia Limited\", role = c(\"ctb\", \"cph\"),\n    comment = \"DataTables library\"),\n    person(\"John\", \"Fraser\", role = c(\"ctb\", \"cph\"),\n    comment = \"showdown.js library\"),\n    person(\"John\", \"Gruber\", role = c(\"ctb\", \"cph\"),\n    comment = \"showdown.js library\"),\n    person(\"Ivan\", \"Sagalaev\", role = c(\"ctb\", \"cph\"),\n    comment = \"highlight.js library\"),\n    person(family = \"R Core Team\", role = c(\"ctb\", \"cph\"),\n    comment = \"tar implementation from R\")\n    )",
         "Description": "Makes it incredibly easy to build interactive web\n    applications with R. Automatic \"reactive\" binding between inputs and\n    outputs and extensive prebuilt widgets make it possible to build\n    beautiful, responsive, and powerful applications with minimal effort.",
         "License": "GPL-3 | file LICENSE",
         "Depends": "R (>= 3.0.2), methods",
-        "Imports": "utils, grDevices, httpuv (>= 1.5.2), mime (>= 0.3), jsonlite\n(>= 0.9.16), xtable, digest, htmltools (>= 0.4.0), R6 (>= 2.0),\nsourcetools, later (>= 1.0.0), promises (>= 1.1.0), tools,\ncrayon, rlang (>= 0.4.0), fastmap (>= 1.0.0)",
-        "Suggests": "datasets, Cairo (>= 1.5-5), testthat (>= 2.1.1), knitr (>=\n1.6), markdown, rmarkdown, ggplot2, reactlog (>= 1.0.0),\nmagrittr, yaml",
+        "Imports": "utils, grDevices, httpuv (>= 1.5.2), mime (>= 0.3), jsonlite\n(>= 0.9.16), xtable, digest, htmltools (>= 0.4.0), R6 (>= 2.0),\nsourcetools, later (>= 1.0.0), promises (>= 1.1.0), tools,\ncrayon, rlang (>= 0.4.0), fastmap (>= 1.0.0), withr",
+        "Suggests": "datasets, Cairo (>= 1.5-5), testthat (>= 2.1.1), knitr (>=\n1.6), markdown, rmarkdown, ggplot2, reactlog (>= 1.0.0),\nmagrittr, shinytest, yaml, future, dygraphs",
         "URL": "http://shiny.rstudio.com",
         "BugReports": "https://github.com/rstudio/shiny/issues",
-        "Collate": "'app.R' 'bookmark-state-local.R' 'stack.R' 'bookmark-state.R'\n'bootstrap-deprecated.R' 'bootstrap-layout.R' 'globals.R'\n'conditions.R' 'map.R' 'utils.R' 'bootstrap.R'\n'cache-context.R' 'cache-disk.R' 'cache-memory.R'\n'cache-utils.R' 'diagnose.R' 'fileupload.R' 'font-awesome.R'\n'graph.R' 'reactives.R' 'reactive-domains.R' 'history.R'\n'hooks.R' 'html-deps.R' 'htmltools.R' 'image-interact-opts.R'\n'image-interact.R' 'imageutils.R' 'input-action.R'\n'input-checkbox.R' 'input-checkboxgroup.R' 'input-date.R'\n'input-daterange.R' 'input-file.R' 'input-numeric.R'\n'input-password.R' 'input-radiobuttons.R' 'input-select.R'\n'input-slider.R' 'input-submit.R' 'input-text.R'\n'input-textarea.R' 'input-utils.R' 'insert-tab.R' 'insert-ui.R'\n'jqueryui.R' 'middleware-shiny.R' 'middleware.R' 'modal.R'\n'modules.R' 'notifications.R' 'priorityqueue.R' 'progress.R'\n'react.R' 'render-cached-plot.R' 'render-plot.R'\n'render-table.R' 'run-url.R' 'serializers.R'\n'server-input-handlers.R' 'server.R' 'shiny-options.R'\n'shiny.R' 'shinyui.R' 'shinywrappers.R' 'showcase.R'\n'snapshot.R' 'tar.R' 'test-export.R' 'timer.R' 'update-input.R'",
-        "RoxygenNote": "6.1.1",
+        "Collate": "'app.R' 'bookmark-state-local.R' 'stack.R' 'bookmark-state.R'\n'bootstrap-deprecated.R' 'bootstrap-layout.R' 'globals.R'\n'conditions.R' 'map.R' 'utils.R' 'bootstrap.R'\n'cache-context.R' 'cache-disk.R' 'cache-memory.R'\n'cache-utils.R' 'diagnose.R' 'fileupload.R' 'font-awesome.R'\n'graph.R' 'reactives.R' 'reactive-domains.R' 'history.R'\n'hooks.R' 'html-deps.R' 'htmltools.R' 'image-interact-opts.R'\n'image-interact.R' 'imageutils.R' 'input-action.R'\n'input-checkbox.R' 'input-checkboxgroup.R' 'input-date.R'\n'input-daterange.R' 'input-file.R' 'input-numeric.R'\n'input-password.R' 'input-radiobuttons.R' 'input-select.R'\n'input-slider.R' 'input-submit.R' 'input-text.R'\n'input-textarea.R' 'input-utils.R' 'insert-tab.R' 'insert-ui.R'\n'jqueryui.R' 'middleware-shiny.R' 'middleware.R' 'timer.R'\n'mock-session.R' 'modal.R' 'modules.R' 'notifications.R'\n'priorityqueue.R' 'progress.R' 'react.R' 'render-cached-plot.R'\n'render-plot.R' 'render-table.R' 'run-url.R' 'serializers.R'\n'server-input-handlers.R' 'server.R' 'shiny-options.R'\n'shiny.R' 'shinyui.R' 'shinywrappers.R' 'showcase.R'\n'snapshot.R' 'tar.R' 'test-export.R' 'test-module.R' 'test.R'\n'update-input.R'",
+        "RoxygenNote": "7.0.2",
         "Encoding": "UTF-8",
+        "Roxygen": "list(markdown = TRUE)",
+        "RemoteType": "github",
+        "RemoteHost": "api.github.com",
+        "RemoteRepo": "shiny",
+        "RemoteUsername": "rstudio",
+        "RemoteRef": "master",
+        "RemoteSha": "e07c7483a79cc641d464cd7496872a28eedbe4a4",
+        "GithubRepo": "shiny",
+        "GithubUsername": "rstudio",
+        "GithubRef": "master",
+        "GithubSHA1": "e07c7483a79cc641d464cd7496872a28eedbe4a4",
         "NeedsCompilation": "no",
-        "Packaged": "2019-10-08 16:21:27 UTC; winston",
+        "Packaged": "2019-12-04 21:10:14 UTC; james",
         "Author": "Winston Chang [aut, cre],\n  Joe Cheng [aut],\n  JJ Allaire [aut],\n  Yihui Xie [aut],\n  Jonathan McPherson [aut],\n  RStudio [cph],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/www/shared/jqueryui/AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Alexander Farkas [ctb, cph] (html5shiv library),\n  Scott Jehl [ctb, cph] (Respond.js library),\n  Stefan Petre [ctb, cph] (Bootstrap-datepicker library),\n  Andrew Rowls [ctb, cph] (Bootstrap-datepicker library),\n  Dave Gandy [ctb, cph] (Font-Awesome font),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Kristopher Michael Kowal [ctb, cph] (es5-shim library),\n  es5-shim contributors [ctb, cph] (es5-shim library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library),\n  SpryMedia Limited [ctb, cph] (DataTables library),\n  John Fraser [ctb, cph] (showdown.js library),\n  John Gruber [ctb, cph] (showdown.js library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  R Core Team [ctb, cph] (tar implementation from R)",
         "Maintainer": "Winston Chang <winston@rstudio.com>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-10-10 12:50:02 UTC",
-        "Built": "R 3.6.1; ; 2019-12-06 18:40:45 UTC; unix"
+        "Built": "R 3.6.0; ; 2019-12-04 21:10:17 UTC; unix"
+      }
+    },
+    "shinymeta": {
+      "Source": "github",
+      "Repository": null,
+      "GithubRepo": "shinymeta",
+      "GithubUsername": "rstudio",
+      "GithubRef": "master",
+      "GithubSha1": "b0ac4551317b07c81e4417fc41bfdda6db474057",
+      "description": {
+        "Package": "shinymeta",
+        "Type": "Package",
+        "Title": "Record and Expose Shiny App Logic using Metaprogramming",
+        "Version": "0.2.0",
+        "Authors@R": "c(\n    person(\"Joe\", \"Cheng\", email = \"joe@rstudio.com\", role = \"cre\"),\n    person(\"Carson\", \"Sievert\", email = \"carson@rstudio.com\", role = \"aut\", comment = c(ORCID = \"0000-0002-4958-2844\")),\n    person(family = \"RStudio\", role = \"cph\")\n    )",
+        "Description": "Provides functions that make it easier to construct Shiny apps\n    that can dynamically construct reproducible R scripts.",
+        "URL": "https://rstudio.github.io/shinymeta,\nhttps://github.com/rstudio/shinymeta",
+        "License": "GPL-3",
+        "Imports": "callr, digest, fastmap, fs, magrittr, rlang, shiny (>=\n1.3.2.9001), sourcetools, styler, utils",
+        "Encoding": "UTF-8",
+        "LazyData": "true",
+        "RoxygenNote": "6.1.1",
+        "Suggests": "knitr, rmarkdown, testthat, shinyAce, clipr, dplyr, ggplot2,\ncranlogs, zoo",
+        "Remotes": "rstudio/shiny",
+        "VignetteBuilder": "knitr",
+        "Roxygen": "list(markdown = TRUE)",
+        "Collate": "'archive.R' 'display.R' 'format.R' 'imports.R' 'utils.R'\n'metareactive.R' 'observe.R' 'globals.R' 'output-code.R'\n'print.R' 'render.R' 'report.R' 'utils-format.R' 'zzz.R'",
+        "RemoteType": "github",
+        "RemoteHost": "api.github.com",
+        "RemoteRepo": "shinymeta",
+        "RemoteUsername": "rstudio",
+        "RemoteRef": "master",
+        "RemoteSha": "b0ac4551317b07c81e4417fc41bfdda6db474057",
+        "GithubRepo": "shinymeta",
+        "GithubUsername": "rstudio",
+        "GithubRef": "master",
+        "GithubSHA1": "b0ac4551317b07c81e4417fc41bfdda6db474057",
+        "NeedsCompilation": "no",
+        "Packaged": "2019-11-08 21:32:30 UTC; james",
+        "Author": "Joe Cheng [cre],\n  Carson Sievert [aut] (<https://orcid.org/0000-0002-4958-2844>),\n  RStudio [cph]",
+        "Maintainer": "Joe Cheng <joe@rstudio.com>",
+        "Built": "R 3.6.0; ; 2019-11-08 21:32:31 UTC; unix"
       }
     },
     "sourcetools": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2008,21 +2229,21 @@
         "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
         "Packaged": "2018-04-25 03:19:22 UTC; kevin",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-04-25 03:38:09 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 14:50:15 UTC; unix"
+        "Built": "R 3.6.2; x86_64-pc-linux-gnu; 2019-12-27 20:35:59 UTC; unix"
       }
     },
     "sp": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
       "GithubSha1": null,
       "description": {
         "Package": "sp",
-        "Version": "1.3-2",
+        "Version": "1.3-1",
         "Title": "Classes and Methods for Spatial Data",
         "Authors@R": "c(person(\"Edzer\", \"Pebesma\", role = c(\"aut\", \"cre\"),\n\t\t\t\temail = \"edzer.pebesma@uni-muenster.de\"),\n\t\t\tperson(\"Roger\", \"Bivand\", role = \"aut\",\n            \temail = \"Roger.Bivand@nhh.no\"),\n\t\t\tperson(\"Barry\", \"Rowlingson\", role = \"ctb\"),\n\t\t\tperson(\"Virgilio\", \"Gomez-Rubio\", role = \"ctb\"),\n\t\t\tperson(\"Robert\", \"Hijmans\", role = \"ctb\"),\n\t\t\tperson(\"Michael\", \"Sumner\", role = \"ctb\"),\n\t\t\tperson(\"Don\", \"MacQueen\", role = \"ctb\"),\n\t\t\tperson(\"Jim\", \"Lemon\", role = \"ctb\"),\n\t\t\tperson(\"Josh\", \"O'Brien\", role = \"ctb\"),\n\t\t\tperson(\"Joseph\", \"O'Rourke\", role = \"ctb\"))",
         "Depends": "R (>= 3.0.0), methods",
@@ -2034,17 +2255,18 @@
         "BugReports": "https://github.com/edzer/sp/issues",
         "Collate": "bpy.colors.R AAA.R Class-CRS.R CRS-methods.R Class-Spatial.R\nSpatial-methods.R projected.R Class-SpatialPoints.R\nSpatialPoints-methods.R Class-SpatialPointsDataFrame.R\nSpatialPointsDataFrame-methods.R Class-SpatialMultiPoints.R\nSpatialMultiPoints-methods.R\nClass-SpatialMultiPointsDataFrame.R\nSpatialMultiPointsDataFrame-methods.R Class-GridTopology.R\nClass-SpatialGrid.R Class-SpatialGridDataFrame.R\nClass-SpatialLines.R SpatialLines-methods.R\nClass-SpatialLinesDataFrame.R SpatialLinesDataFrame-methods.R\nClass-SpatialPolygons.R Class-SpatialPolygonsDataFrame.R\nSpatialPolygons-methods.R SpatialPolygonsDataFrame-methods.R\nGridTopology-methods.R SpatialGrid-methods.R\nSpatialGridDataFrame-methods.R SpatialPolygons-internals.R\npoint.in.polygon.R SpatialPolygons-displayMethods.R zerodist.R\nimage.R stack.R bubble.R mapasp.R select.spatial.R gridded.R\nasciigrid.R spplot.R over.R spsample.R recenter.R dms.R\ngridlines.R spdists.R rbind.R flipSGDF.R chfids.R loadmeuse.R\ncompassRose.R surfaceArea.R spOptions.R subset.R disaggregate.R\nsp_spat1.R merge.R aggregate.R",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-11-07 21:08:22 UTC; edzer",
+        "Packaged": "2018-06-05 09:56:27 UTC; edzer",
         "Author": "Edzer Pebesma [aut, cre],\n  Roger Bivand [aut],\n  Barry Rowlingson [ctb],\n  Virgilio Gomez-Rubio [ctb],\n  Robert Hijmans [ctb],\n  Michael Sumner [ctb],\n  Don MacQueen [ctb],\n  Jim Lemon [ctb],\n  Josh O'Brien [ctb],\n  Joseph O'Rourke [ctb]",
         "Maintainer": "Edzer Pebesma <edzer.pebesma@uni-muenster.de>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-11-07 23:00:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-11-23 19:51:47 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2018-06-05 13:58:03 UTC",
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:33:29 UTC; unix"
       }
     },
     "stringi": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2069,14 +2291,15 @@
         "NeedsCompilation": "yes",
         "Packaged": "2019-03-12 21:12:07 UTC; gagolews",
         "License_is_FOSS": "yes",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-03-12 23:20:03 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 14:53:22 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-23 20:00:14 UTC; unix"
       }
     },
     "stringr": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2101,14 +2324,47 @@
         "Packaged": "2019-02-09 16:03:19 UTC; hadley",
         "Author": "Hadley Wickham [aut, cre, cph],\n  RStudio [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-02-10 03:40:03 UTC",
-        "Built": "R 3.6.1; ; 2019-07-29 13:45:45 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-23 20:06:12 UTC; unix"
+      }
+    },
+    "styler": {
+      "Source": "CRAN",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "styler",
+        "Type": "Package",
+        "Title": "Non-Invasive Pretty Printing of R Code",
+        "Version": "1.2.0",
+        "Authors@R": "\n    c(person(given = \"Kirill\",\n             family = \"Müller\",\n             role = \"aut\",\n             email = \"krlmlr+r@mailbox.org\"),\n      person(given = \"Lorenz\",\n             family = \"Walthert\",\n             role = c(\"cre\", \"aut\"),\n             email = \"lorenz.walthert@icloud.com\"))",
+        "Description": "Pretty-prints R code without changing the user's\n    formatting intent.",
+        "License": "GPL-3",
+        "URL": "https://github.com/r-lib/styler",
+        "BugReports": "https://github.com/r-lib/styler/issues",
+        "Imports": "backports (>= 1.1.0), cli (>= 1.1.0), magrittr (>= 1.0.1),\npurrr (>= 0.2.3), rematch2 (>= 2.0.1), rlang (>= 0.1.1),\nrprojroot (>= 1.1), tibble (>= 1.4.2), tools, withr (>= 1.0.0),\nxfun (>= 0.1)",
+        "Suggests": "data.tree (>= 0.1.6), dplyr, here, knitr, prettycode,\nrmarkdown, rstudioapi (>= 0.7), testthat (>= 2.1.0)",
+        "VignetteBuilder": "knitr",
+        "Encoding": "UTF-8",
+        "LazyData": "true",
+        "RoxygenNote": "6.1.1",
+        "Collate": "'addins.R' 'communicate.R' 'compat-dplyr.R' 'compat-tidyr.R'\n'detect-alignment-utils.R' 'detect-alignment.R'\n'environments.R' 'expr-is.R' 'indent.R' 'initialize.R' 'io.R'\n'nest.R' 'nested-to-tree.R' 'parse.R' 'reindent.R'\n'token-define.R' 'relevel.R' 'roxygen-examples-add-remove.R'\n'roxygen-examples-find.R' 'roxygen-examples-parse.R'\n'roxygen-examples.R' 'rules-line-break.R' 'rules-other.R'\n'rules-replacement.R' 'rules-spacing.R' 'serialize.R'\n'set-assert-args.R' 'style-guides.R' 'styler.R'\n'testing-mocks.R' 'testing-public-api.R' 'testing.R'\n'token-create.R' 'transform-code.R' 'transform-files.R' 'ui.R'\n'unindent.R' 'utils-files.R' 'utils-navigate-nest.R'\n'utils-strings.R' 'utils.R' 'vertical.R' 'visit.R' 'zzz.R'",
+        "NeedsCompilation": "no",
+        "Packaged": "2019-10-17 18:22:11 UTC; lorenz",
+        "Author": "Kirill Müller [aut],\n  Lorenz Walthert [cre, aut]",
+        "Maintainer": "Lorenz Walthert <lorenz.walthert@icloud.com>",
+        "Repository": "CRAN",
+        "Date/Publication": "2019-10-17 20:20:02 UTC",
+        "Built": "R 3.6.0; ; 2019-11-08 21:28:48 UTC; unix"
       }
     },
     "sys": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2117,11 +2373,11 @@
         "Package": "sys",
         "Type": "Package",
         "Title": "Powerful and Reliable Tools for Running System Commands in R",
-        "Version": "3.3",
+        "Version": "3.2",
         "Authors@R": "c(person(\"Jeroen\", \"Ooms\", role = c(\"aut\", \"cre\"), \n      email = \"jeroen@berkeley.edu\", comment = c(ORCID = \"0000-0002-4035-0289\")),\n    person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = \"ctb\"))",
         "Description": "Drop-in replacements for the base system2() function with fine control\n    and consistent behavior across platforms. Supports clean interruption, timeout, \n    background tasks, and streaming STDIN / STDOUT / STDERR over binary or text \n    connections. Arguments on Windows automatically get encoded and quoted to work \n    on different locales.",
         "License": "MIT + file LICENSE",
-        "URL": "https://github.com/jeroen/sys",
+        "URL": "https://github.com/jeroen/sys#readme",
         "BugReports": "https://github.com/jeroen/sys/issues",
         "Encoding": "UTF-8",
         "LazyData": "true",
@@ -2129,17 +2385,17 @@
         "Suggests": "unix (>= 1.4), spelling, testthat",
         "Language": "en-US",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-08-21 11:45:42 UTC; jeroen",
+        "Packaged": "2019-04-23 21:04:34 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Gábor Csárdi [ctb]",
         "Maintainer": "Jeroen Ooms <jeroen@berkeley.edu>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-08-21 14:20:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-03 14:44:27 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-04-23 22:40:08 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-01 20:44:48 UTC; unix"
       }
     },
     "tibble": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2165,14 +2421,14 @@
         "Packaged": "2019-06-06 12:40:47 UTC; kirill",
         "Author": "Kirill Müller [aut, cre],\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  RStudio [cph]",
         "Maintainer": "Kirill Müller <krlmlr+r@mailbox.org>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-06-06 13:40:03 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-06-11 22:17:32 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:46:15 UTC; unix"
       }
     },
     "tidyselect": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2196,14 +2452,14 @@
         "Packaged": "2018-10-11 12:25:22 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  RStudio [cph]",
         "Maintainer": "Lionel Henry <lionel@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-10-11 13:00:03 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 15:02:33 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-05 08:06:37 UTC; unix"
       }
     },
     "tinytex": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2212,7 +2468,7 @@
         "Package": "tinytex",
         "Type": "Package",
         "Title": "Helper Functions to Install and Maintain 'TeX Live', and Compile\n'LaTeX' Documents",
-        "Version": "0.17",
+        "Version": "0.14",
         "Authors@R": "c(\n  person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\", \"cph\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\")),\n  person(family = \"RStudio, Inc.\", role = \"cph\"),\n  person(\"Fernando\", \"Cagua\", role = \"ctb\"),\n  person(\"Ethan\", \"Heinzen\", role = \"ctb\"),\n  person()\n  )",
         "Description": "Helper functions to install and maintain the 'LaTeX' distribution\n  named 'TinyTeX' (<https://yihui.name/tinytex/>), a lightweight, cross-platform,\n  portable, and easy-to-maintain version of 'TeX Live'. This package also\n  contains helper functions to compile 'LaTeX' documents, and install missing\n  'LaTeX' packages automatically.",
         "Imports": "xfun (>= 0.5)",
@@ -2224,17 +2480,17 @@
         "LazyData": "true",
         "RoxygenNote": "6.1.1",
         "NeedsCompilation": "no",
-        "Packaged": "2019-10-30 18:18:22 UTC; yihui",
+        "Packaged": "2019-06-25 04:07:18 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (<https://orcid.org/0000-0003-0645-5666>),\n  RStudio, Inc. [cph],\n  Fernando Cagua [ctb],\n  Ethan Heinzen [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
-        "Date/Publication": "2019-10-30 23:00:02 UTC",
-        "Built": "R 3.6.1; ; 2019-11-23 19:57:13 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-06-25 06:00:03 UTC",
+        "Built": "R 3.6.1; ; 2019-08-01 20:45:34 UTC; unix"
       }
     },
     "utf8": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2257,56 +2513,47 @@
         "Packaged": "2018-05-24 15:00:57 UTC; ptrck",
         "Author": "Patrick O. Perry [aut, cph, cre],\n  Unicode, Inc. [cph, dtc] (Unicode Character Database)",
         "Maintainer": "Patrick O. Perry <patperry@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-05-24 17:09:15 UTC",
-        "Built": "R 3.6.0; x86_64-pc-linux-gnu; 2019-04-28 14:54:11 UTC; unix"
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:33:27 UTC; unix"
       }
     },
     "vctrs": {
-      "Source": "github",
-      "Repository": null,
-      "GithubRepo": "vctrs",
-      "GithubUsername": "r-lib",
-      "GithubRef": "master",
-      "GithubSha1": "fb03c046456828a86bb42e4eb7009e1fe9e7beed",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
       "description": {
         "Package": "vctrs",
         "Title": "Vector Helpers",
-        "Version": "0.2.0.9007",
+        "Version": "0.2.0",
         "Authors@R": "\n    c(person(given = \"Hadley\",\n             family = \"Wickham\",\n             role = c(\"aut\", \"cre\"),\n             email = \"hadley@rstudio.com\"),\n      person(given = \"Lionel\",\n             family = \"Henry\",\n             role = \"aut\",\n             email = \"lionel@rstudio.com\"),\n      person(given = \"Davis\",\n             family = \"Vaughan\",\n             role = \"aut\",\n             email = \"davis@rstudio.com\"),\n      person(given = \"RStudio\",\n             role = \"cph\"))",
-        "Description": "Defines new notions of prototype and size that are\n    used to provide tools for consistent and well-founded type-coercion\n    and size-recycling, and are in turn connected to ideas of type- and\n    size-stability useful for analysing function interfaces.",
+        "Description": "Defines new notions of prototype and size that are\n    used to provide tools for consistent and well-founded type-coercion\n    and size-recycling, and are in turn connected to ideas of type- and\n    size-stability useful for analyzing function interfaces.",
         "License": "GPL-3",
         "URL": "https://github.com/r-lib/vctrs",
         "BugReports": "https://github.com/r-lib/vctrs/issues",
         "Depends": "R (>= 3.2)",
-        "Imports": "ellipsis (>= 0.2.0), digest, glue, rlang (>= 0.4.2)",
-        "Suggests": "bit64, covr, crayon, generics, knitr, pillar (>= 1.4.1),\npkgdown, rmarkdown, testthat (>= 2.3.0), tibble, xml2, zeallot",
+        "Imports": "backports, ellipsis (>= 0.2.0), digest, glue, rlang (>=\n0.4.0), zeallot",
+        "Suggests": "bit64, covr, crayon, generics, knitr, pillar (>= 1.4.1),\npkgdown, rmarkdown, testthat, tibble",
         "VignetteBuilder": "knitr",
         "Encoding": "UTF-8",
         "Language": "en-GB",
         "LazyData": "true",
-        "Roxygen": "list(markdown = TRUE)",
-        "RoxygenNote": "7.0.1",
-        "RemoteType": "github",
-        "RemoteHost": "api.github.com",
-        "RemoteRepo": "vctrs",
-        "RemoteUsername": "r-lib",
-        "RemoteRef": "master",
-        "RemoteSha": "fb03c046456828a86bb42e4eb7009e1fe9e7beed",
-        "GithubRepo": "vctrs",
-        "GithubUsername": "r-lib",
-        "GithubRef": "master",
-        "GithubSHA1": "fb03c046456828a86bb42e4eb7009e1fe9e7beed",
+        "RoxygenNote": "6.1.1",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-12-06 20:33:09 UTC; edgar",
+        "Packaged": "2019-07-02 19:29:52 UTC; lionel",
         "Author": "Hadley Wickham [aut, cre],\n  Lionel Henry [aut],\n  Davis Vaughan [aut],\n  RStudio [cph]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-12-06 20:33:10 UTC; unix"
+        "Repository": "RSPM",
+        "Date/Publication": "2019-07-05 23:00:04 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-26 13:38:16 UTC; unix"
       }
     },
     "viridis": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2332,14 +2579,14 @@
         "NeedsCompilation": "no",
         "Packaged": "2018-03-29 14:51:56 UTC; simon",
         "Author": "Simon Garnier [aut, cre],\n  Noam Ross [ctb, cph],\n  Bob Rudis [ctb, cph],\n  Marco Sciaini [ctb, cph],\n  Cédric Scherer [ctb, cph]",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-03-29 15:48:56 UTC",
-        "Built": "R 3.6.0; ; 2019-05-13 16:18:22 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-23 20:09:56 UTC; unix"
       }
     },
     "viridisLite": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2363,14 +2610,14 @@
         "NeedsCompilation": "no",
         "Packaged": "2018-02-01 17:33:56 UTC; simon",
         "Author": "Simon Garnier [aut, cre],\n  Noam Ross [ctb, cph],\n  Bob Rudis [ctb, cph],\n  Marco Sciaini [ctb, cph],\n  Cédric Scherer [ctb, cph]",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-02-01 22:45:56 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 14:53:15 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-26 13:38:26 UTC; unix"
       }
     },
     "withr": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2396,14 +2643,14 @@
         "Packaged": "2018-03-15 13:59:37 UTC; jhester",
         "Author": "Jim Hester [aut, cre],\n  Kirill Müller [aut],\n  Kevin Ushey [aut],\n  Hadley Wickham [aut],\n  Winston Chang [aut],\n  Richard Cotton [ctb],\n  RStudio [cph]",
         "Maintainer": "Jim Hester <james.f.hester@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-03-15 22:39:56 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 14:55:12 UTC; unix"
+        "Built": "R 3.6.1; ; 2019-09-26 13:32:57 UTC; unix"
       }
     },
     "xfun": {
       "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2412,7 +2659,7 @@
         "Package": "xfun",
         "Type": "Package",
         "Title": "Miscellaneous Functions by 'Yihui Xie'",
-        "Version": "0.11",
+        "Version": "0.10",
         "Authors@R": "c(\n  person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\", \"cph\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\")),\n  person(\"Daijiang\", \"Li\", role = \"ctb\"),\n  person(\"Xianying\", \"Tan\", role = \"ctb\"),\n  person(\"Salim\", \"Brüggemann\", role = \"ctb\", email = \"salim-b@pm.me\"),\n  person()\n  )",
         "Description": "Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.",
         "Imports": "stats, tools",
@@ -2425,17 +2672,17 @@
         "RoxygenNote": "6.1.1",
         "VignetteBuilder": "knitr",
         "NeedsCompilation": "no",
-        "Packaged": "2019-11-12 15:31:12 UTC; yihui",
+        "Packaged": "2019-10-01 15:28:13 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (<https://orcid.org/0000-0003-0645-5666>),\n  Daijiang Li [ctb],\n  Xianying Tan [ctb],\n  Salim Brüggemann [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
-        "Date/Publication": "2019-11-12 17:40:02 UTC",
-        "Built": "R 3.6.1; ; 2019-11-23 19:52:04 UTC; unix"
+        "Date/Publication": "2019-10-01 18:20:02 UTC",
+        "Built": "R 3.6.0; ; 2019-11-08 21:28:05 UTC; unix"
       }
     },
     "xtable": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2454,17 +2701,18 @@
         "URL": "http://xtable.r-forge.r-project.org/",
         "Depends": "R (>= 2.10.0)",
         "License": "GPL (>= 2)",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "NeedsCompilation": "no",
         "Packaged": "2019-04-21 10:56:51 UTC; dsco036",
         "Author": "David B. Dahl [aut],\n  David Scott [aut, cre],\n  Charles Roosen [aut],\n  Arni Magnusson [aut],\n  Jonathan Swinton [aut],\n  Ajay Shah [ctb],\n  Arne Henningsen [ctb],\n  Benno Puetz [ctb],\n  Bernhard Pfaff [ctb],\n  Claudio Agostinelli [ctb],\n  Claudius Loehnert [ctb],\n  David Mitchell [ctb],\n  David Whiting [ctb],\n  Fernando da Rosa [ctb],\n  Guido Gay [ctb],\n  Guido Schulz [ctb],\n  Ian Fellows [ctb],\n  Jeff Laake [ctb],\n  John Walker [ctb],\n  Jun Yan [ctb],\n  Liviu Andronic [ctb],\n  Markus Loecher [ctb],\n  Martin Gubri [ctb],\n  Matthieu Stigler [ctb],\n  Robert Castelo [ctb],\n  Seth Falcon [ctb],\n  Stefan Edwards [ctb],\n  Sven Garbade [ctb],\n  Uwe Ligges [ctb]",
         "Date/Publication": "2019-04-21 12:20:03 UTC",
-        "Built": "R 3.6.0; ; 2019-04-28 14:51:48 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.2; ; 2019-12-27 20:35:59 UTC; unix"
       }
     },
     "yaml": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2484,14 +2732,45 @@
         "BugReports": "https://github.com/viking/r-yaml/issues",
         "NeedsCompilation": "yes",
         "Packaged": "2018-07-24 19:09:41 UTC; stephej1",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-07-25 15:40:03 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-07-29 13:45:46 UTC; unix"
+        "Encoding": "UTF-8",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-23 20:07:02 UTC; unix"
+      }
+    },
+    "zeallot": {
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
+      "GithubRepo": null,
+      "GithubUsername": null,
+      "GithubRef": null,
+      "GithubSha1": null,
+      "description": {
+        "Package": "zeallot",
+        "Type": "Package",
+        "Title": "Multiple, Unpacking, and Destructuring Assignment",
+        "Version": "0.1.0",
+        "Authors@R": "c(\n    person(given = \"Nathan\", family = \"Teetor\", email = \"nathanteetor@gmail.com\", role = c(\"aut\", \"cre\")),\n    person(given = \"Paul\", family = \"Teetor\", role = \"ctb\"))",
+        "Description": "Provides a %<-% operator to perform multiple,\n    unpacking, and destructuring assignment in R. The \n    operator unpacks the right-hand side of an assignment\n    into multiple values and assigns these values to \n    variables on the left-hand side of the assignment.",
+        "URL": "https://github.com/nteetor/zeallot",
+        "BugReports": "https://github.com/nteetor/zeallot/issues",
+        "License": "MIT + file LICENSE",
+        "Encoding": "UTF-8",
+        "RoxygenNote": "6.0.1",
+        "VignetteBuilder": "knitr",
+        "Suggests": "testthat, knitr, rmarkdown, purrr, magrittr",
+        "NeedsCompilation": "no",
+        "Packaged": "2018-01-27 17:18:33 UTC; nteetor",
+        "Author": "Nathan Teetor [aut, cre],\n  Paul Teetor [ctb]",
+        "Maintainer": "Nathan Teetor <nathanteetor@gmail.com>",
+        "Repository": "RSPM",
+        "Date/Publication": "2018-01-28 16:14:13 UTC",
+        "Built": "R 3.6.1; ; 2019-09-26 13:36:45 UTC; unix"
       }
     },
     "zip": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
+      "Source": "RSPM",
+      "Repository": "https://demo.rstudiopm.com/all/__linux__/bionic/1654",
       "GithubRepo": null,
       "GithubUsername": null,
       "GithubRef": null,
@@ -2499,7 +2778,7 @@
       "description": {
         "Package": "zip",
         "Title": "Cross-Platform 'zip' Compression",
-        "Version": "2.0.4",
+        "Version": "2.0.3",
         "Author": "Gábor Csárdi, Kuba Podgórski, Rich Geldreich",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Description": "Cross-Platform 'zip' Compression Library. A replacement\n    for the 'zip' function, that does not require any additional\n    external tools on any platform.",
@@ -2511,265 +2790,289 @@
         "Suggests": "covr, processx, R6, testthat, withr",
         "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
-        "Packaged": "2019-09-01 08:28:20 UTC; gaborcsardi",
+        "Packaged": "2019-07-03 10:27:59 UTC; gaborcsardi",
         "Repository": "RSPM",
-        "Date/Publication": "2019-09-01 08:50:02 UTC",
-        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-09-12 16:45:40 UTC; unix"
+        "Date/Publication": "2019-07-03 10:50:40 UTC",
+        "Built": "R 3.6.1; x86_64-pc-linux-gnu; 2019-08-29 11:31:45 UTC; unix"
       }
     }
   },
   "files": {
     "access-to-care.Rmd": {
-      "checksum": "f9afc7613b647328ad5d1d886397a6fb"
+      "checksum": "0001b62e1832dd58f0f9dcac549c0d72"
+    },
+    "metadata.yml": {
+      "checksum": "6a089bf7d5d485378e5a4f92cad4ad42"
     },
     "model.png": {
       "checksum": "d43a7d18e1310610959315a3023f2020"
     },
     "packrat/desc/askpass": {
-      "checksum": "adb6f14233aa229a9245fbe85bd572d6"
+      "checksum": "5babf9db572d334d07d512511e8aded4"
     },
     "packrat/desc/assertthat": {
-      "checksum": "225699cd8daad6332ccb6c6e9f4497f6"
+      "checksum": "b171a4a0ba807207f64db7fd0d63caf3"
+    },
+    "packrat/desc/backports": {
+      "checksum": "91576fdfe8fdf522d02f11418e577a41"
     },
     "packrat/desc/base64enc": {
-      "checksum": "362ea9ff1fc894a11fd5f13c6c7044d5"
+      "checksum": "72f484389842ce16ebd7fbe4c11936ef"
     },
     "packrat/desc/BH": {
-      "checksum": "198d2958d305790c2b2e83c2271a89a1"
+      "checksum": "4d5756a32369d03b5bf44a27891505a5"
+    },
+    "packrat/desc/callr": {
+      "checksum": "2771af9760b8f6bb3e089212c142c085"
     },
     "packrat/desc/cli": {
-      "checksum": "26bc32342ff6e339a36ad8dd1714152f"
+      "checksum": "a65c30681395287318eddb8c16cc4eec"
     },
     "packrat/desc/colorspace": {
-      "checksum": "9accdaca7a2ff925abbb0983f52fdbf0"
+      "checksum": "ca7b0eb3d7b8bafd2b6631c90ac81cea"
     },
     "packrat/desc/crayon": {
-      "checksum": "b904732d2ef8151af8505f65ca9bf2c8"
+      "checksum": "3009348e6160b875a09849914127106c"
     },
     "packrat/desc/crosstalk": {
-      "checksum": "b9ad1fd2b802a888562cb46fde1bce26"
+      "checksum": "08bfac49a8f0894183594098c0825c4e"
     },
     "packrat/desc/curl": {
-      "checksum": "bd3c8ced68e5f75a2491165227db1c76"
+      "checksum": "6984c0e4a15550c7a57ac395d63b8db8"
     },
     "packrat/desc/digest": {
-      "checksum": "eb52a3dd6c1a94208b2abc95ba58d6f6"
+      "checksum": "db95b45f9e17608bedb6e3ebc8f7434c"
     },
     "packrat/desc/dplyr": {
-      "checksum": "53e6401db1734aa27c5de477bbf86bba"
+      "checksum": "0654cfd2c84e841c51027d8240119875"
     },
     "packrat/desc/DT": {
-      "checksum": "e0abd5abd8e77fa95dd845ca223c12e4"
+      "checksum": "0160e099f0199076be97cd0b1d40a5be"
     },
     "packrat/desc/ellipsis": {
-      "checksum": "815b3786f5eaaa618c753e37d017f75c"
+      "checksum": "f8940115c3de14708d5d809ae710a122"
     },
     "packrat/desc/evaluate": {
-      "checksum": "96de8d176c6babf7390bfe31e4bedd48"
+      "checksum": "5f0c0432947a890646880d400c6d3b3e"
     },
     "packrat/desc/fansi": {
-      "checksum": "5845d939324ef796cb5e2f365be33155"
-    },
-    "packrat/desc/farver": {
-      "checksum": "07c603486f2b57171ad31eab4ec12310"
+      "checksum": "a8b15d9589b3780b9c9fbe55d1172fc6"
     },
     "packrat/desc/fastmap": {
-      "checksum": "c80a8ffba92725ae2851a2c3c1758fdb"
+      "checksum": "e7c82150e39ab2f2f9ccd6671b452de6"
     },
     "packrat/desc/flexdashboard": {
-      "checksum": "de10f1f054082fa8afcecf17a22dce28"
+      "checksum": "264726066b8de466d9774b53f4b128dd"
+    },
+    "packrat/desc/fs": {
+      "checksum": "fa97e7047faba142f8d75a36bfd4044c"
     },
     "packrat/desc/ggplot2": {
-      "checksum": "ad2db3c1f244c1ee38ff712c0fed5fdf"
+      "checksum": "165d2bd959ec69397df17537cbaa4a6d"
     },
     "packrat/desc/glue": {
-      "checksum": "a37e19669d16e5ccff0e69bdc8835999"
+      "checksum": "f2f00727e071abeadb0cc3dbbe45f902"
     },
     "packrat/desc/gridExtra": {
-      "checksum": "5fe7a819e530281775f188fcbad1923e"
+      "checksum": "078ad6bbc4f1061b171bcb5217483aee"
     },
     "packrat/desc/gtable": {
-      "checksum": "91ab96944a3121b8303398c43d1aed99"
+      "checksum": "882395eed2b5fae577a193ce1d9525a2"
     },
     "packrat/desc/highr": {
-      "checksum": "f7b8c5c73dac0dc8c0dd3fa2d09f28ea"
+      "checksum": "02014090e6c3d9df230ffc602d2c114f"
     },
     "packrat/desc/htmltools": {
-      "checksum": "096fd4286b92b5f2f7da730dfc36c477"
+      "checksum": "d798fc3930309137de6d2590373ba10e"
     },
     "packrat/desc/htmlwidgets": {
-      "checksum": "ff99f614cf244fc94033f1f7089e2242"
+      "checksum": "f5582d7efbb98ff6f2f00d0efc65cedf"
     },
     "packrat/desc/httpuv": {
-      "checksum": "30891e460cae502d6773fd2a9f70c1c5"
+      "checksum": "0fedac1500f93fe8071fc2a98f9f5e44"
     },
     "packrat/desc/httr": {
-      "checksum": "25c2b2da5dfd1557cf5640d4f4fe2c5a"
+      "checksum": "071ba9b1f6a8a7dd8a475f5e4bd74ec6"
     },
     "packrat/desc/jsonlite": {
-      "checksum": "1975be5aabd799a923f2a5f611c0b526"
+      "checksum": "45d208c5094dc4bdd2a0a07b4e2024ce"
     },
     "packrat/desc/knitr": {
-      "checksum": "a1b2775e604cea7fcb0ec9753ea57d7d"
+      "checksum": "a2abc5044d8e1f1844b97350d3130d1e"
     },
     "packrat/desc/labeling": {
-      "checksum": "f9f3c1705243315bb459cdc9bb5c91d6"
+      "checksum": "3910a2fdb9867235ee1e80e8c59724a9"
     },
     "packrat/desc/later": {
-      "checksum": "871b45a7118b1a624bb47139c2bbf886"
+      "checksum": "4f86112bb8b29781b2cb487dbc28883b"
     },
     "packrat/desc/lattice": {
-      "checksum": "c71e45f10c9540f19acaae763aff1d5d"
+      "checksum": "ab23ee2964c9b1a7d13cca59c08062e6"
     },
     "packrat/desc/lazyeval": {
-      "checksum": "528dbf79107ad7cf7a366b999b96eb13"
+      "checksum": "8f68250532bafe421c42056ee807493b"
     },
     "packrat/desc/leaflet": {
-      "checksum": "c88a67b7170e35aab2817664d824cf74"
-    },
-    "packrat/desc/leaflet.providers": {
-      "checksum": "0c961f517eed67a7c83dc9146efdeddf"
-    },
-    "packrat/desc/lifecycle": {
-      "checksum": "c764bbda07dfe89da0413448cdaceb8f"
+      "checksum": "89ac4bd5e5020e7e791f5ad69604e9dd"
     },
     "packrat/desc/magrittr": {
-      "checksum": "3a1abf625d42aed8e042fd2409952088"
+      "checksum": "dcce0bdbd647711dae3d552ebbf280aa"
     },
     "packrat/desc/markdown": {
-      "checksum": "08a94b35a65faef89977b39f11e6f3f9"
+      "checksum": "ae32ae28a9fdbd910e0d9291914538d1"
     },
     "packrat/desc/MASS": {
-      "checksum": "a1669d126a3dc0213ac4d86558bf7e29"
+      "checksum": "b390c19ec804dd03e326b57f5962d7d3"
     },
     "packrat/desc/Matrix": {
-      "checksum": "bdc59ccc8442b14444e731c12addf100"
+      "checksum": "f50f6363c46d27b6c2fa9a62a1c1bcf6"
     },
     "packrat/desc/metricsgraphics": {
-      "checksum": "31d3c6c2a91a9e3eecb5cefe4cee1528"
+      "checksum": "1b4aa2efe2d3ad1552ba9f48f567cd37"
     },
     "packrat/desc/mgcv": {
-      "checksum": "3322e1ba5ad4d21f42dbfa87333048e7"
+      "checksum": "c26481231b764b255dfc188505106555"
     },
     "packrat/desc/mime": {
-      "checksum": "d128bf809e8fd56cd02537d229f66bf2"
+      "checksum": "0d97a3cac3f03d09952ddefbdfdd090b"
     },
     "packrat/desc/munsell": {
-      "checksum": "8c7c66bd28ceae30e0af6836731e9961"
+      "checksum": "dffcde42a8ef6e47157d0b50ac20c849"
     },
     "packrat/desc/nlme": {
-      "checksum": "0fe01c2edc4e99539e6e6bbb05692c47"
+      "checksum": "8f248de83ad73f553f9f97fa8ec42b96"
     },
     "packrat/desc/openssl": {
-      "checksum": "df489c9cc292f74875c80af9a7942ce7"
+      "checksum": "78f270c9afcb4bfecdd19dbe1e692969"
     },
     "packrat/desc/pillar": {
-      "checksum": "5ed755f867065bd0b75e138ba094c383"
+      "checksum": "b3ba10f4887f52e13532e5469b875af4"
     },
     "packrat/desc/pins": {
-      "checksum": "f2d184a459fd2baf2b7756fd2376f27f"
+      "checksum": "0b70570f2108b49e713a4b6ccd6b2106"
     },
     "packrat/desc/pkgconfig": {
-      "checksum": "fc4964d60c231621cdf59f7bf241718c"
+      "checksum": "1d82067bb8c76ebb7ed1513fd287b138"
     },
     "packrat/desc/plogr": {
-      "checksum": "bc785ead95d5e207b759336655defb75"
+      "checksum": "81dca0054c82811198992e454fae13f5"
     },
     "packrat/desc/plyr": {
-      "checksum": "eb1f46fce2788277b7eceac961945abd"
+      "checksum": "65578e3a48aa02be59e44b6ca73f32a3"
     },
     "packrat/desc/png": {
-      "checksum": "0326da4a3dfd6d5f096d9bdb488b0371"
+      "checksum": "8a1fd9d6ff5e56b641cd00a732dd10fd"
+    },
+    "packrat/desc/processx": {
+      "checksum": "df06f630e16bc703f1feed8e3c11daa3"
     },
     "packrat/desc/promises": {
-      "checksum": "e759eeef96e2395e5c81beeb8eda1460"
+      "checksum": "72f7ab4331b609b4c3779df1b06726a3"
+    },
+    "packrat/desc/ps": {
+      "checksum": "1c84fa678ea6c67537dd47074a43f340"
     },
     "packrat/desc/purrr": {
-      "checksum": "e835a6eec8e8fdefef2be10cab65549a"
+      "checksum": "5ebea74629afd41c612756716d442050"
     },
     "packrat/desc/R6": {
-      "checksum": "b0dc134d088affcb344c4dce629a5941"
+      "checksum": "77d6a69ea384a72bb1886dffe4cafdf1"
     },
     "packrat/desc/rappdirs": {
-      "checksum": "3d2fa14330c5e90dea9fc04b54ad169a"
+      "checksum": "8125c08567860abb707ba64b4adf4c2b"
     },
     "packrat/desc/raster": {
-      "checksum": "a4fc0ec72338c3b5a02845f8954be5c7"
+      "checksum": "43842c07bcf7cbb910a6fe0b60628def"
     },
     "packrat/desc/RColorBrewer": {
-      "checksum": "b6eb091d8bc6eb4c6d297b0d0f337b67"
+      "checksum": "c6f2b0f308fc2c4cbbd80425782002c6"
     },
     "packrat/desc/Rcpp": {
-      "checksum": "8f85a14a7dbfdd75e9546b77e4715fe2"
+      "checksum": "6ed5d53682df3b9dc3ff3a203748ae70"
+    },
+    "packrat/desc/rematch2": {
+      "checksum": "66ce3a208f88d1983c20e5289ef02007"
     },
     "packrat/desc/reshape2": {
-      "checksum": "a1966f37efdca71c4a97f9a903ffce9e"
+      "checksum": "8a455f7c64efa2a42ce4d81606a7c3be"
     },
     "packrat/desc/rlang": {
-      "checksum": "dfbc99a8e4137b41412488efe6b1a8aa"
+      "checksum": "19f4f8be80099cff99d3f021629b7352"
     },
     "packrat/desc/rmarkdown": {
-      "checksum": "00414a7f18ba335184a87f1408580be6"
+      "checksum": "5a3a47ae01f560f71dfd790ea4dc6652"
+    },
+    "packrat/desc/rprojroot": {
+      "checksum": "e1529fad357c0b10afb519e5bfcd72f9"
     },
     "packrat/desc/scales": {
-      "checksum": "7bd55442221f5eda225e5dbd1cc53300"
+      "checksum": "02dd17cd0e15fdf6aaa64f09f39305cf"
     },
     "packrat/desc/shiny": {
-      "checksum": "1c17554d8dd67d9d6fcd21e86ed2ef61"
+      "checksum": "ae9028e249107ae8e103e8f3840af5a3"
+    },
+    "packrat/desc/shinymeta": {
+      "checksum": "23e8bfe686aa192bf8cd2c4b398b5480"
     },
     "packrat/desc/sourcetools": {
-      "checksum": "2f7acb4111861a38bf1203f9145c2bca"
+      "checksum": "8e7f7181f6ed6b46dc15a166cc07bfa6"
     },
     "packrat/desc/sp": {
-      "checksum": "0a527fa16de478447009cc9030580866"
+      "checksum": "e68f7229b618ee73300bdca21f8b6ea8"
     },
     "packrat/desc/stringi": {
-      "checksum": "9e4df8d97d2fafb03ebf2cf04b36e1b1"
+      "checksum": "cf9554bc268e3d8188a7d155079ffcec"
     },
     "packrat/desc/stringr": {
-      "checksum": "766051c3edeb630d8273c65e4a7a6e6a"
+      "checksum": "b50ca25c58190e25272b7c7319b1b15f"
+    },
+    "packrat/desc/styler": {
+      "checksum": "0cbf9f137f9d784887f10250602753ed"
     },
     "packrat/desc/sys": {
-      "checksum": "d17122905bd826ac2737607af8d33e91"
+      "checksum": "702075f86d37f9daf353a7f1cb153768"
     },
     "packrat/desc/tibble": {
-      "checksum": "d30896a4c06b43a3196d1630c70da048"
+      "checksum": "ae28aea379ebf3ccf4e313185ddea956"
     },
     "packrat/desc/tidyselect": {
-      "checksum": "a45200e9c6943a298d53337efb7c0670"
+      "checksum": "29ca8fbc27eb4f2e26b1a6d9f05fada2"
     },
     "packrat/desc/tinytex": {
-      "checksum": "2004363d151216cdff7cbdf8c93a2130"
+      "checksum": "1a67293b457e4c5eb26b55db27ac8c76"
     },
     "packrat/desc/utf8": {
-      "checksum": "1bf4fed895f4bcc93cc2ed9593338a30"
+      "checksum": "7100b459223f06adfe4ee6d512d0e9bd"
     },
     "packrat/desc/vctrs": {
-      "checksum": "be5263b54c168f8ff81d45ff7b61e9d5"
+      "checksum": "f0aee65dd2a13ee76c86ead9c87fd205"
     },
     "packrat/desc/viridis": {
-      "checksum": "557ec8702387c7f336efd3d168c69416"
+      "checksum": "972e589bd1f57dd21528900762d800b1"
     },
     "packrat/desc/viridisLite": {
-      "checksum": "e92e2838055d56f70ca43c7b550f5aa6"
+      "checksum": "141c27f1e85eb3e6f378244b7a2f9b92"
     },
     "packrat/desc/withr": {
-      "checksum": "7e8c9f5d08e946c8fdd2f25bc3883de2"
+      "checksum": "19f02a8c35c8df7da7563b605daedb4c"
     },
     "packrat/desc/xfun": {
-      "checksum": "cd618ac40268837824f46dce9ae4e73d"
+      "checksum": "b25f1094a5cc1398a4592185efd17818"
     },
     "packrat/desc/xtable": {
-      "checksum": "6d416bbfb18cf8fa44927055b28c5fa0"
+      "checksum": "1c6278abc71ea59ec88c101360bbea4e"
     },
     "packrat/desc/yaml": {
-      "checksum": "8bc153008a9c1767a35689eb7e2328b2"
+      "checksum": "db54e4727238e1f2f842433d14d36e74"
+    },
+    "packrat/desc/zeallot": {
+      "checksum": "70aefe01321bab01dbe9fc9db0de951d"
     },
     "packrat/desc/zip": {
-      "checksum": "df9935ffca693dfde7b99a6283f9db00"
+      "checksum": "e3293f6b22b641db2a78a50f8c24d8eb"
     },
     "packrat/packrat.lock": {
-      "checksum": "5fc8afe5ae14bc3d8da8c47820e47a8a"
+      "checksum": "09132b3263cc30e02a413b4b3af4d79e"
     },
     "RStudio1.png": {
       "checksum": "288da77036023512c0adbf27de9fe9c2"


### PR DESCRIPTION
Add [`shinymeta`](https://rstudio.github.io/shinymeta/index.html) to flexdashboard. This creates a button at the bottom of the State Info tab that  opens a modal containing the R code needed to generate the leaflet plot and DT table:

![image](https://user-images.githubusercontent.com/10444878/72172498-7f2b3000-3392-11ea-8b7e-3c95c1f41553.png)

_Since this was developed on Colorado, the manifest changes significantly and now points to a frozen snapshot on RSPM instead of CRAN_
